### PR TITLE
CLI skeleton

### DIFF
--- a/pip_audit/cli.py
+++ b/pip_audit/cli.py
@@ -17,7 +17,7 @@ class OutputFormat(str, enum.Enum):
     Output formats supported by the `pip-audit` CLI.
     """
 
-    Plain = "plain"
+    Columns = "columns"
     Json = "json"
 
     def __str__(self):
@@ -59,7 +59,7 @@ def audit():
         "--format",
         type=OutputFormat,
         choices=OutputFormat,
-        default=OutputFormat.Plain,
+        default=OutputFormat.Columns,
         help="the format to emit audit results in",
     )
     parser.add_argument(

--- a/pip_audit/cli.py
+++ b/pip_audit/cli.py
@@ -2,9 +2,80 @@
 Command-line entrypoints for `pip-audit`.
 """
 
+import argparse
+import enum
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=os.environ.get("PIP_AUDIT_LOGLEVEL", "INFO").upper())
+
+
+@enum.unique
+class OutputFormat(str, enum.Enum):
+    """
+    Output formats supported by the `pip-audit` CLI.
+    """
+
+    Plain = "plain"
+    Json = "json"
+
+    def __str__(self):
+        return self.value
+
+
+@enum.unique
+class VulnerabilityService(str, enum.Enum):
+    """
+    Python vulnerability services supported by `pip-audit`.
+    """
+
+    Osv = "osv"
+    Pypi = "pypi"
+
+    def __str__(self):
+        return self.value
+
 
 def audit():
     """
     The primary entrypoint for `pip-audit`.
     """
-    print("Hello from pip-audit!")
+    parser = argparse.ArgumentParser(
+        description="audit the Python environment for dependencies with known vulnerabilities",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-r",
+        "--requirement",
+        type=argparse.FileType("r"),
+        action="append",
+        default=[],
+        dest="requirements",
+        help="audit the given requirements file; this option can be used multiple times",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=OutputFormat,
+        choices=OutputFormat,
+        default=OutputFormat.Plain,
+        help="the format to emit audit results in",
+    )
+    parser.add_argument(
+        "-s",
+        "--vulnerability-service",
+        type=VulnerabilityService,
+        choices=VulnerabilityService,
+        default=VulnerabilityService.Osv,
+        help="the vulnerability service to audit dependencies against",
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="collect all dependencies but do not perform the auditing step",
+    )
+
+    args = parser.parse_args()
+    logger.debug(f"parsed arguments: {args}")

--- a/pip_audit/service/__init__.py
+++ b/pip_audit/service/__init__.py
@@ -2,6 +2,6 @@ from .interface import (  # noqa: F401
     Dependency,
     ServiceError,
     VulnerabilityResult,
-    VulnerabilityService
+    VulnerabilityService,
 )
 from .osv import OsvService  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 line_length = 100
 multi_line_output = 3
 known_first_party = "pip_audit"
+include_trailing_comma = true
 
 [tool.black]
 line-length = 100

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ from pip_audit.service.interface import (
     Dependency,
     VersionRange,
     VulnerabilityResult,
-    VulnerabilityService
+    VulnerabilityService,
 )
 
 


### PR DESCRIPTION
As-is:

```
usage: pip-audit [-h] [-r REQUIREMENTS] [-f {plain,json}] [-s {osv,pypi}] [-d]

audit the Python environment for dependencies with known vulnerabilities

optional arguments:
  -h, --help            show this help message and exit
  -r REQUIREMENTS, --requirement REQUIREMENTS
                        audit the given requirements file; this option can be
                        used multiple times (default: [])
  -f {plain,json}, --format {plain,json}
                        the format to emit audit results in (default: plain)
  -s {osv,pypi}, --vulnerability-service {osv,pypi}
                        the vulnerability service to audit dependencies
                        against (default: osv)
  -d, --dry-run         collect all dependencies but do not perform the
                        auditing step (default: False)
```

I'll create individual board items for the functionality under each of these flags.