### PR TITLE
Remove subdependency pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
     platforms="any",
     python_requires=">=3.6",
     install_requires=[
-        "pip-api==0.0.20",
-        "packaging==21.0.0",
+        "pip-api>=0.0.20",
+        "packaging>=21.0.0",
         # TODO: Remove this once 3.7 is our minimally supported version.
-        "dataclasses==0.6",
+        "dataclasses>=0.6",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Subdependencies of a package shouldn't be pinned as it increases the likelihood of an unresolvable dependency set.