### PR TITLE
Progress indicator

### DIFF
--- a/pip_audit/audit.py
+++ b/pip_audit/audit.py
@@ -47,8 +47,7 @@ class Auditor:
 
         if self._options.dry_run:
             # Drain the iterator in dry-run mode.
-            for spec in specs:
-                logger.info(f"Dry run: would have audited {spec.package}")
+            logger.info(f"Dry run: would have audited {len(list(specs))} packages")
             return {}
         else:
             yield from self._service.query_all(specs)

--- a/pip_audit/cli.py
+++ b/pip_audit/cli.py
@@ -7,6 +7,8 @@ import enum
 import logging
 import os
 
+from progress.spinner import Spinner  # type: ignore
+
 from pip_audit.audit import AuditOptions, Auditor
 from pip_audit.dependency_source import PipSource
 from pip_audit.format import ColumnsFormat, JsonFormat, VulnerabilityFormat
@@ -111,4 +113,8 @@ def audit():
     source = PipSource()
     auditor = Auditor(service, options=AuditOptions(dry_run=args.dry_run))
 
-    print(formatter.format(auditor.audit(source)))
+    result = {}
+    for (spec, vulns) in Spinner("Auditing").iter(auditor.audit(source)):
+        result[spec] = vulns
+
+    print(formatter.format(result))

--- a/pip_audit/cli.py
+++ b/pip_audit/cli.py
@@ -6,8 +6,9 @@ import argparse
 import enum
 import logging
 import os
+from typing import Any, Dict
 
-from progress.spinner import Spinner  # type: ignore
+from progress.spinner import Spinner as BaseSpinner  # type: ignore
 
 from pip_audit.audit import AuditOptions, Auditor
 from pip_audit.dependency_source import PipSource
@@ -17,6 +18,22 @@ from pip_audit.util import assert_never
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("PIP_AUDIT_LOGLEVEL", "INFO").upper())
+
+
+class AuditSpinner(BaseSpinner):
+    def __init__(self, message: str = "", **kwargs: Dict[str, Any]):
+        super().__init__(message=message, **kwargs)
+        self._base_message = self.message
+
+    def update(self):
+        item = getattr(self, "iter_value", None)
+        if item is not None:
+            (spec, _) = item
+            self.message = f"{self._base_message} {spec.package} ({spec.version})"
+
+        i = self.index % len(self.phases)
+        line = f"{self.phases[i]} {self.message}"
+        self.writeln(line)
 
 
 @enum.unique
@@ -114,7 +131,7 @@ def audit():
     auditor = Auditor(service, options=AuditOptions(dry_run=args.dry_run))
 
     result = {}
-    for (spec, vulns) in Spinner("Auditing").iter(auditor.audit(source)):
+    for (spec, vulns) in AuditSpinner("Auditing").iter(auditor.audit(source)):
         result[spec] = vulns
 
     print(formatter.format(result))

--- a/pip_audit/cli.py
+++ b/pip_audit/cli.py
@@ -15,6 +15,7 @@ from pip_audit.dependency_source import PipSource
 from pip_audit.format import ColumnsFormat, JsonFormat, VulnerabilityFormat
 from pip_audit.service import OsvService, VulnerabilityService
 from pip_audit.util import assert_never
+from pip_audit.version import __version__
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("PIP_AUDIT_LOGLEVEL", "INFO").upper())
@@ -83,9 +84,11 @@ def audit():
     The primary entrypoint for `pip-audit`.
     """
     parser = argparse.ArgumentParser(
+        prog="pip-audit",
         description="audit the Python environment for dependencies with known vulnerabilities",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument(
         "-r",
         "--requirement",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "packaging>=21.0.0",
         # TODO: Remove this once 3.7 is our minimally supported version.
         "dataclasses>=0.6",
+        "progress>=1.6",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Adds a `progress` based progress indicator to the CLI.

Some notes:

* I've subclasses `progress.spinner.Spinner` into `AuditSpinner` to make it behave a little better (the spin icon is on the LHS now, and we show each item being processed to give the user more feedback)
* I've confirmed that the default behavior of `progress` is reasonable when `stdout`/`stderr` aren't TTYs and that it doesn't interfere with our logging or other output