### PR TITLE
service/pypi: Use full cache path instead of directory name

### DIFF
--- a/pip_audit/service/pypi.py
+++ b/pip_audit/service/pypi.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from subprocess import run
 from tempfile import NamedTemporaryFile
 from typing import Any, List, Optional
 
@@ -92,7 +93,7 @@ def _get_pip_cache() -> str:
     # the `pip` HTTP cache
     cmd = [sys.executable, "-m", "pip", "cache", "dir"]
     try:
-        process = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        process = run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError as cpe:  # pragma: no cover
         raise ServiceError(f"Failed to query the `pip` HTTP cache directory: {cmd}") from cpe
     cache_dir = process.stdout.decode("utf-8").strip("\n")

--- a/pip_audit/service/pypi.py
+++ b/pip_audit/service/pypi.py
@@ -105,7 +105,7 @@ def _get_cache_dir(custom_cache_dir: Optional[Path]) -> str:
         _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
     )
     if custom_cache_dir is not None:
-        return custom_cache_dir.name
+        return str(custom_cache_dir)
     elif pip_cache_dir is not None:  # pragma: no cover
         return pip_cache_dir
     else:

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -7,6 +7,7 @@ import requests
 from packaging.version import Version
 
 import pip_audit.service as service
+from pip_audit.service.pypi import _get_cache_dir
 
 cache_dir: Optional[tempfile.TemporaryDirectory] = None
 
@@ -207,3 +208,44 @@ def test_pypi_warns_about_old_pip(monkeypatch):
     # have an old `pip`, then we should expect a warning to be logged
     service.PyPIService()
     assert len(logger.warning.calls) == 1
+
+
+def test_pypi_cache_dir(monkeypatch):
+    # When we supply a cache directory, always use that
+    cache_dir: str = _get_cache_dir("/tmp/foo/cache_dir")
+    assert cache_dir == "/tmp/foo/cache_dir"
+
+    def run_mock(args, **kwargs):
+        class MockProcess:
+            def __init__(self, stdout_str: str):
+                self.stdout: bytes = stdout_str.encode("utf-8")
+
+        return MockProcess("/Users/foo/Library/Caches/pip")
+
+    # Without a cache dir, query `pip` for its HTTP cache and then append `http` at the end
+    monkeypatch.setattr(service.pypi, "run", run_mock)
+
+    cache_dir = _get_cache_dir(None)
+    assert cache_dir == "/Users/foo/Library/Caches/pip/http"
+
+
+def test_pypi_cache_dir_old_pip(monkeypatch):
+    # Check the case where we have an old `pip`
+    monkeypatch.setattr(service.pypi, "_PIP_VERSION", Version("1.0.0"))
+
+    # When we supply a cache directory, always use that
+    cache_dir: str = _get_cache_dir("/tmp/foo/cache_dir")
+    assert cache_dir == "/tmp/foo/cache_dir"
+
+    # Mock out home since this is going to be different across systems
+    class MockPath:
+        @staticmethod
+        def home():
+            return "/Users/foo"
+
+    # In this case, we can't query `pip` to figure out where its HTTP cache is
+    # Instead, we use `~/.pip-audit-cache`
+    monkeypatch.setattr(service.pypi, "Path", MockPath)
+
+    cache_dir = _get_cache_dir(None)
+    assert cache_dir == "/Users/foo/.pip-audit-cache"


### PR DESCRIPTION
Closes #131