### PR TITLE
_cli, setup: experimental tab completion generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,30 +40,28 @@ optional arguments:
   -l, --local           show only results for dependencies in the local
                         environment (default: False)
   -r REQUIREMENTS, --requirement REQUIREMENTS
-                        audit the given requirements file; this option can
-                        be used multiple times (default: None)
+                        audit the given requirements file; this option can be
+                        used multiple times (default: None)
   -f {columns,json,cyclonedx-json,cyclonedx-xml}, --format {columns,json,cyclonedx-json,cyclonedx-xml}
-                        the format to emit audit results in (default:
-                        columns)
+                        the format to emit audit results in (default: columns)
   -s {osv,pypi}, --vulnerability-service {osv,pypi}
                         the vulnerability service to audit dependencies
                         against (default: pypi)
   -d, --dry-run         collect all dependencies but do not perform the
                         auditing step (default: False)
-  --desc {on,off,auto}  include a description for each vulnerability;
-                        `auto` defaults to `on` for the `json` format. This
-                        flag has no effect on the `cyclonedx-json` or
-                        `cyclonedx-xml` formats. (default: auto)
+  --desc {on,off,auto}  include a description for each vulnerability; `auto`
+                        defaults to `on` for the `json` format. This flag has
+                        no effect on the `cyclonedx-json` or `cyclonedx-xml`
+                        formats. (default: auto)
   --cache-dir CACHE_DIR
-                        the directory to use as an HTTP cache for PyPI;
-                        uses the `pip` HTTP cache by default (default:
-                        None)
+                        the directory to use as an HTTP cache for PyPI; uses
+                        the `pip` HTTP cache by default (default: None)
   --progress-spinner {on,off}
                         display a progress spinner (default: on)
   --timeout TIMEOUT     set the socket timeout (default: 15)
   --completions {bash,zsh,tcsh}
-                        generate tab completion for the given shell
-                        (default: None)
+                        generate tab completion for the given shell (default:
+                        None)
 ```
 <!-- @end-pip-audit-help@ -->
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ usage: pip-audit [-h] [-V] [-l] [-r REQUIREMENTS]
                  [-f {columns,json,cyclonedx-json,cyclonedx-xml}]
                  [-s {osv,pypi}] [-d] [--desc {on,off,auto}]
                  [--cache-dir CACHE_DIR] [--progress-spinner {on,off}]
-                 [--timeout TIMEOUT]
+                 [--timeout TIMEOUT] [--completions {bash,zsh,tcsh}]
 
 audit the Python environment for dependencies with known vulnerabilities
 
@@ -40,25 +40,30 @@ optional arguments:
   -l, --local           show only results for dependencies in the local
                         environment (default: False)
   -r REQUIREMENTS, --requirement REQUIREMENTS
-                        audit the given requirements file; this option can be
-                        used multiple times (default: None)
+                        audit the given requirements file; this option can
+                        be used multiple times (default: None)
   -f {columns,json,cyclonedx-json,cyclonedx-xml}, --format {columns,json,cyclonedx-json,cyclonedx-xml}
-                        the format to emit audit results in (default: columns)
+                        the format to emit audit results in (default:
+                        columns)
   -s {osv,pypi}, --vulnerability-service {osv,pypi}
                         the vulnerability service to audit dependencies
                         against (default: pypi)
   -d, --dry-run         collect all dependencies but do not perform the
                         auditing step (default: False)
-  --desc {on,off,auto}  include a description for each vulnerability; `auto`
-                        defaults to `on` for the `json` format. This flag has
-                        no effect on the `cyclonedx-json` or `cyclonedx-xml`
-                        formats. (default: auto)
+  --desc {on,off,auto}  include a description for each vulnerability;
+                        `auto` defaults to `on` for the `json` format. This
+                        flag has no effect on the `cyclonedx-json` or
+                        `cyclonedx-xml` formats. (default: auto)
   --cache-dir CACHE_DIR
-                        the directory to use as an HTTP cache for PyPI; uses
-                        the `pip` HTTP cache by default (default: None)
+                        the directory to use as an HTTP cache for PyPI;
+                        uses the `pip` HTTP cache by default (default:
+                        None)
   --progress-spinner {on,off}
                         display a progress spinner (default: on)
   --timeout TIMEOUT     set the socket timeout (default: 15)
+  --completions {bash,zsh,tcsh}
+                        generate tab completion for the given shell
+                        (default: None)
 ```
 <!-- @end-pip-audit-help@ -->
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -11,6 +11,8 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import List, Optional
 
+import shtab  # type: ignore
+
 from pip_audit import __version__
 from pip_audit._audit import AuditOptions, Auditor
 from pip_audit._dependency_source import (
@@ -186,9 +188,19 @@ def audit() -> None:
     parser.add_argument(
         "--timeout", type=int, default=15, help="set the socket timeout"  # Match the `pip` default
     )
+    parser.add_argument(
+        "--completions",
+        type=str,
+        choices=shtab.SUPPORTED_SHELLS,
+        help="generate tab completion for the given shell",
+    )
 
     args = parser.parse_args()
     logger.debug(f"parsed arguments: {args}")
+
+    if args.completions is not None:
+        print(shtab.complete(parser, shell=args.completions))
+        return
 
     service = args.vulnerability_service.to_service(args.timeout, args.cache_dir)
     output_desc = args.desc.to_bool(args.format)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "CacheControl>=0.12.10",
         "lockfile>=0.12.2",
         "cyclonedx-python-lib>=0.11.1",
+        "shtab>=1.5.1",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
This is a **demonstration** of what automatic tab completion generation for `pip-audit` might look like. It uses [shtab](https://github.com/iterative/shtab), which does the generation under the hood without requiring more invasive system hooks.

Example use (where `<tab>` indicates a physical tab):

```bash
$ eval "$(pip-audit --completions=bash)"

$ pip-audit -<tab>
--cache-dir              --progress-spinner       -f
--completions            --requirement            -h
--desc                   --timeout                -l
--dry-run                --version                -r
--format                 --vulnerability-service  -s
--help                   -V
--local                  -d

$ pip-audit --vulnerability-service<tab>
osv   pypi
```

This approach seems relatively extensible (`shtab` seems to support completion extensions, like indicating that an option takes filenames only) as well.