### PR TITLE
_service/pypi.py: Do not execute pip cache command when a custom directory is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ All versions prior to 0.0.9 are untracked.
   `--strict` mode) is produced
   ([#162](https://github.com/trailofbits/pip-audit/pull/162))
 
+* CLI: When providing the `--cache-dir` flag, the command to read the pip cache
+  directory is no longer executed. Previously this was always executed and
+  could result into failure when the command fails. In CI environments, the
+  default `~/.cache` directory is typically not writable by the build user and
+  this meant that the `python -m pip cache dir` would fail before this fix,
+  even if the `--cache-dir` flag was provided.
+  ([#161](https://github.com/trailofbits/pip-audit/pull/161))
+
 ### Removed
 
 ## [1.0.0] - 2021-12-1

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -109,12 +109,11 @@ def _get_pip_cache() -> str:
 
 
 def _get_cache_dir(custom_cache_dir: Optional[Path]) -> str:
-    pip_cache_dir: Optional[str] = (
-        _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
-    )
     if custom_cache_dir is not None:
         return str(custom_cache_dir)
-    elif pip_cache_dir is not None:  # pragma: no cover
+    elif (
+        pip_cache_dir := _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
+    ) is not None:  # pragma: no cover
         return pip_cache_dir
     else:
         fallback_path = os.path.join(Path.home(), ".pip-audit-cache")

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -111,9 +111,9 @@ def _get_pip_cache() -> str:
 def _get_cache_dir(custom_cache_dir: Optional[Path]) -> str:
     if custom_cache_dir is not None:
         return str(custom_cache_dir)
-    elif (
-        pip_cache_dir := _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
-    ) is not None:  # pragma: no cover
+
+    pip_cache_dir = _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
+    if pip_cache_dir is not None:  # pragma: no cover
         return pip_cache_dir
     else:
         fallback_path = os.path.join(Path.home(), ".pip-audit-cache")


### PR DESCRIPTION
In a scenario where the pip cache directory isn't available because the
user doesn't have permissions; pip will error with this message:

```
ERROR: pip cache commands cannot function since cache is disabled.
```

This currently cannot be mitigated by specifying the `--cache-dir` flag
because the `python -m pip cache dir` command is execute before this
predicate is evaluated. By using an assignment expression (PEP 572), we
can evaluate whether the expression evaluates to a truthy value in the
`elif` branch (saving it's return value) AFTER first evaluating the
custom directory value.