### PR TITLE
_dependency_source: Return a `SkippedDependency` when the resolver can't find a project on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All versions prior to 0.0.9 are untracked.
   as a bare option, `--desc` is equivalent to `--desc on`
   ([#153](https://github.com/trailofbits/pip-audit/pull/153))
 
+* Dependency resolution: The PyPI-based dependency resolver no longer throws
+  an uncaught exception on package resolution errors; instead, the package
+  is marked as skipped and an appropriate warning or fatal error (in
+  `--strict` mode) is produced
+  ([#162](https://github.com/trailofbits/pip-audit/pull/162))
+
 ### Removed
 
 ## [1.0.0] - 2021-12-1

--- a/pip_audit/_dependency_source/interface.py
+++ b/pip_audit/_dependency_source/interface.py
@@ -50,7 +50,7 @@ class DependencyResolver(ABC):
     @abstractmethod
     def resolve(self, req: Requirement) -> List[Dependency]:  # pragma: no cover
         """
-        Resolve a single `Requirement` into a list of concrete `Dependency` instances.
+        Resolve a single `Requirement` into a list of `Dependency` instances.
         """
         raise NotImplementedError
 

--- a/pip_audit/_dependency_source/interface.py
+++ b/pip_audit/_dependency_source/interface.py
@@ -8,7 +8,7 @@ from typing import Iterator, List, Tuple
 
 from packaging.requirements import Requirement
 
-from pip_audit._service import Dependency, ResolvedDependency
+from pip_audit._service import Dependency
 
 
 class DependencySource(ABC):
@@ -48,7 +48,7 @@ class DependencyResolver(ABC):
     """
 
     @abstractmethod
-    def resolve(self, req: Requirement) -> List[ResolvedDependency]:  # pragma: no cover
+    def resolve(self, req: Requirement) -> List[Dependency]:  # pragma: no cover
         """
         Resolve a single `Requirement` into a list of concrete `Dependency` instances.
         """
@@ -56,7 +56,7 @@ class DependencyResolver(ABC):
 
     def resolve_all(
         self, reqs: Iterator[Requirement]
-    ) -> Iterator[Tuple[Requirement, List[ResolvedDependency]]]:
+    ) -> Iterator[Tuple[Requirement, List[Dependency]]]:
         """
         Resolve a collection of `Requirement`s into their respective `Dependency` sets.
 

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -3,7 +3,7 @@ Collect dependencies from one or more `requirements.txt`-formatted files.
 """
 
 from pathlib import Path
-from typing import Iterator, List, Optional, Set
+from typing import Iterator, List, Optional, Set, cast
 
 from packaging.requirements import Requirement
 from pip_api import parse_requirements
@@ -16,6 +16,7 @@ from pip_audit._dependency_source import (
     DependencySourceError,
 )
 from pip_audit._service import Dependency
+from pip_audit._service.interface import ResolvedDependency, SkippedDependency
 from pip_audit._state import AuditState
 
 
@@ -65,9 +66,14 @@ class RequirementSource(DependencySource):
                         if dep in collected:
                             continue
                         if self.state is not None:
-                            self.state.update_state(
-                                f"Collecting {dep.name} ({dep.version})"
-                            )  # pragma: no cover
+                            if dep.is_skipped():
+                                dep = cast(SkippedDependency, dep)
+                                self.state.update_state(f"Skipping {dep.name}: {dep.skip_reason}")
+                            else:
+                                dep = cast(ResolvedDependency, dep)
+                                self.state.update_state(
+                                    f"Collecting {dep.name} ({dep.version})"
+                                )  # pragma: no cover
                         collected.add(dep)
                         yield dep
             except DependencyResolverError as dre:

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -65,15 +65,13 @@ class RequirementSource(DependencySource):
                         # Don't allow duplicate dependencies to be returned
                         if dep in collected:
                             continue
-                        if self.state is not None:
+                        if self.state is not None:  # pragma: no cover
                             if dep.is_skipped():
                                 dep = cast(SkippedDependency, dep)
                                 self.state.update_state(f"Skipping {dep.name}: {dep.skip_reason}")
                             else:
                                 dep = cast(ResolvedDependency, dep)
-                                self.state.update_state(
-                                    f"Collecting {dep.name} ({dep.version})"
-                                )  # pragma: no cover
+                                self.state.update_state(f"Collecting {dep.name} ({dep.version})")
                         collected.add(dep)
                         yield dep
             except DependencyResolverError as dre:

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -185,6 +185,8 @@ def get_project_from_pypi(project, extras, timeout: Optional[int], state: Option
     """Return candidates created from the project name and extras."""
     url = "https://pypi.org/simple/{}".format(project)
     response: requests.Response = requests.get(url, timeout=timeout)
+    if response.status_code == 404:
+        raise PyPINotFoundError(f"Could not find project {project} on PyPI")
     response.raise_for_status()
     data = response.content
     doc = html5lib.parse(data, namespaceHTMLElements=False)
@@ -291,3 +293,11 @@ class PyPIProvider(AbstractProvider):
         See `resolvelib.providers.AbstractProvider.get_dependencies`.
         """
         return candidate.dependencies
+
+
+class PyPINotFoundError(Exception):
+    """
+    An error to signify that the provider could not find the requested project on PyPI.
+    """
+
+    pass

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -186,7 +186,7 @@ def get_project_from_pypi(project, extras, timeout: Optional[int], state: Option
     url = "https://pypi.org/simple/{}".format(project)
     response: requests.Response = requests.get(url, timeout=timeout)
     if response.status_code == 404:
-        raise PyPINotFoundError(f"Could not find project {project} on PyPI")
+        raise PyPINotFoundError(f'Could not find project "{project}" on PyPI')
     response.raise_for_status()
     data = response.content
     doc = html5lib.parse(data, namespaceHTMLElements=False)


### PR DESCRIPTION
Closes #157