### PR TITLE
pip_audit, test: perform even more PyPI caching

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -254,7 +254,9 @@ def audit() -> None:
         source: DependencySource
         if args.requirements is not None:
             req_files: List[Path] = [Path(req.name) for req in args.requirements]
-            source = RequirementSource(req_files, ResolveLibResolver(args.timeout, state), state)
+            source = RequirementSource(
+                req_files, ResolveLibResolver(args.timeout, args.cache_dir, state), state
+            )
         else:
             source = PipSource(local=args.local, paths=args.paths)
 

--- a/pip_audit/_dependency_source/resolvelib/resolvelib.py
+++ b/pip_audit/_dependency_source/resolvelib/resolvelib.py
@@ -4,6 +4,7 @@ Resolve a list of dependencies via the `resolvelib` API as well as a custom
 """
 
 import logging
+from pathlib import Path
 from typing import List, Optional
 
 from packaging.requirements import Requirement
@@ -25,13 +26,21 @@ class ResolveLibResolver(DependencyResolver):
     backend dependency resolution strategy.
     """
 
-    def __init__(self, timeout: Optional[int] = None, state: AuditState = AuditState()) -> None:
+    def __init__(
+        self,
+        timeout: Optional[int] = None,
+        cache_dir: Optional[Path] = None,
+        state: AuditState = AuditState(),
+    ) -> None:
         """
         Create a new `ResolveLibResolver`.
 
+        `timeout` and `cache_dir` are optional arguments for HTTP timeouts
+        and caching, respectively.
+
         `state` is an `AuditState` to use for state callbacks.
         """
-        self.provider = PyPIProvider(timeout, state)
+        self.provider = PyPIProvider(timeout, cache_dir, state)
         self.reporter = BaseReporter()
         self.resolver: Resolver = Resolver(self.provider, self.reporter)
 

--- a/test/dependency_source/test_resolvelib.py
+++ b/test/dependency_source/test_resolvelib.py
@@ -129,12 +129,16 @@ def test_resolvelib_wheel_patched(monkeypatch):
         "Flask-2.0.1-py3-none-any.whl</a><br/>"
     )
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
+    # monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_wheel", lambda _: get_metadata_mock()
     )
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     resolved_deps = dict(resolver.resolve_all(iter([req])))
     assert req in resolved_deps
@@ -149,12 +153,15 @@ def test_resolvelib_sdist_patched(monkeypatch, suffix):
     # everything works end-to-end.
     data = f'<a href="https://example.com/Flask-2.0.1.{suffix}">Flask-2.0.1.{suffix}</a><br/>'
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_sdist", lambda _: get_metadata_mock()
     )
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     resolved_deps = dict(resolver.resolve_all(iter([req])))
     assert req in resolved_deps
@@ -172,9 +179,11 @@ def test_resolvelib_wheel_python_version(monkeypatch):
         'data-requires-python="&lt;=2.7">Flask-2.0.1-py3-none-any.whl</a><br/>'
     )
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
-
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     with pytest.raises(ResolutionImpossible):
         dict(resolver.resolve_all(iter([req])))
@@ -190,12 +199,15 @@ def test_resolvelib_wheel_canonical_name_mismatch(monkeypatch):
         "Mask-2.0.1-py3-none-any.whl</a><br/>"
     )
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_wheel", lambda _: get_metadata_mock()
     )
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     with pytest.raises(InconsistentCandidate):
         dict(resolver.resolve_all(iter([req])))
@@ -211,12 +223,15 @@ def test_resolvelib_wheel_invalid_version(monkeypatch):
         "Flask-INVALID.VERSION-py3-none-any.whl</a><br/>"
     )
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_wheel", lambda _: get_metadata_mock()
     )
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     with pytest.raises(ResolutionImpossible):
         dict(resolver.resolve_all(iter([req])))
@@ -226,12 +241,15 @@ def test_resolvelib_sdist_invalid_suffix(monkeypatch):
     # Give the sdist an invalid suffix like ".foo" and insure that it gets skipped.
     data = '<a href="https://example.com/Flask-2.0.1.foo">Flask-2.0.1.foo</a><br/>'
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_package_mock(data))
     monkeypatch.setattr(
         pypi_provider.Candidate, "_get_metadata_for_wheel", lambda _: get_metadata_mock()
     )
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_package_mock(data)
+    )
+
     req = Requirement("flask==2.0.1")
     with pytest.raises(ResolutionImpossible):
         dict(resolver.resolve_all(iter([req])))
@@ -251,6 +269,10 @@ def test_resolvelib_http_error(monkeypatch):
     monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_http_error_mock())
 
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_http_error_mock()
+    )
+
     req = Requirement("flask==2.0.1")
     with pytest.raises(resolvelib.ResolveLibResolverError):
         dict(resolver.resolve_all(iter([req])))
@@ -264,9 +286,11 @@ def test_resolvelib_http_notfound(monkeypatch):
 
         return Doc()
 
-    monkeypatch.setattr(requests, "get", lambda _url, **kwargs: get_http_not_found_mock())
-
     resolver = resolvelib.ResolveLibResolver()
+    monkeypatch.setattr(
+        resolver.provider.session, "get", lambda _url, **kwargs: get_http_not_found_mock()
+    )
+
     req = Requirement("flask==2.0.1")
     resolved_deps = dict(resolver.resolve_all(iter([req])))
     assert len(resolved_deps) == 1


### PR DESCRIPTION
This expands our HTTP caching to include all requests during dependency collection, not just auditing.

Using a very small and contrived input, I see a roughly 10% performance improvement.

Cold starts:

```
real    0m10.721s
user    0m7.593s
sys     0m1.881s

real    0m11.205s
user    0m7.718s
sys     0m1.911s

real    0m11.056s
user    0m7.637s
sys     0m1.889s
```

Versus hot starts:

```
real    0m9.909s
user    0m7.412s
sys     0m1.818s

real    0m10.006s
user    0m7.403s
sys     0m1.827s

real    0m10.248s
user    0m7.491s
sys     0m1.863s
```

Those numbers should be even better for real dependency trees, since we'd expect (1) for users to have a lot cached already, and (2) for medium-to-large projects to have a large number of mutual transitive dependencies.

Closes #187.