### PR TITLE
Added conda install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 pip-audit
 =========
 
+<!--- BADGES: START --->
 ![CI](https://github.com/trailofbits/pip-audit/workflows/CI/badge.svg)
-[![PyPI version](https://badge.fury.io/py/pip-audit.svg)](https://badge.fury.io/py/pip-audit)
+[![PyPI version](https://badge.fury.io/py/pip-audit.svg)][#pypi-package]
+[![Conda - Platform](https://img.shields.io/conda/pn/conda-forge/pip-audit?logo=anaconda&style=flat)][#conda-forge-package]
+[![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/pip-audit?logo=anaconda&style=flat&color=orange)][#conda-forge-package]
+[![GitHub - License](https://img.shields.io/github/license/trailofbits/pip-audit?logo=github&style=flat&color=green)][#github-license]
+
+[#github-license]: https://github.com/trailofbits/pip-audit/blob/main/LICENSE
+[#pypi-package]: https://pypi.org/project/pip-audit/
+[#conda-forge-package]: https://anaconda.org/conda-forge/pip-audit
+<!--- BADGES: END --->
 
 `pip-audit` is a tool for scanning Python environments for packages
 with known vulnerabilities. It uses the Python Packaging Advisory Database
@@ -28,10 +37,18 @@ support from Google. This is not an official Google product.
 ## Installation
 
 `pip-audit` requires Python 3.6 or newer, and can be installed directly via
-`pip`:
+`pip` or `conda`.
+
+**with pip**
 
 ```bash
 python -m pip install pip-audit
+```
+
+**with conda**
+
+```bash
+conda install -c conda-forge pip-audit
 ```
 
 ## Usage


### PR DESCRIPTION
This closes issue #199.

- [x] Readme file was updated (installation section)
- [x] Added some badges (conda-forge, license). 

---

The PR (https://github.com/conda-forge/staged-recipes/pull/17235) for adding `pip-audit` to conda-forge was recently merged.

![image](https://user-images.githubusercontent.com/10201242/145811691-33ba4cac-88c6-41d5-acef-720d26f11376.png)
