### PR TITLE
setup: use CacheControl[filecache]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pip-audit
 
 <!--- BADGES: START --->
 ![CI](https://github.com/trailofbits/pip-audit/workflows/CI/badge.svg)
-[![PyPI version](https://badge.fury.io/py/pip-audit.svg)](https://badge.fury.io/py/pip-audit)
+[![PyPI version](https://badge.fury.io/py/pip-audit.svg)](https://pypi.org/project/pip-audit)
 [![Packaging status](https://repology.org/badge/tiny-repos/python:pip-audit.svg)](https://repology.org/project/python:pip-audit/versions)
 <!--- BADGES: END --->
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "resolvelib>=0.8.0",
         "html5lib>=1.1",
         "CacheControl>=0.12.10",
+        # NOTE: Non-default internal dependency of CacheControl.
         "lockfile>=0.12.2",
         "cyclonedx-python-lib>=0.11.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,7 @@ setup(
         "progress>=1.6",
         "resolvelib>=0.8.0",
         "html5lib>=1.1",
-        "CacheControl>=0.12.10",
-        # NOTE: Non-default internal dependency of CacheControl.
-        "lockfile>=0.12.2",
+        "CacheControl[filecache]>=0.12.10",
         "cyclonedx-python-lib>=0.11.1",
     ],
     extras_require={


### PR DESCRIPTION
~~Clarifies why we need `lockfile` even though it doesn't appear anywhere in `pip-audit`'s own code.~~

With this, all of the dependencies in #203 are accounted for on our side.

Closes #203.