### PR TITLE
Option to skip dependencies with empty PyPI listing.

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -151,6 +151,11 @@ def audit() -> None:
         action="store_true",
         help="show only results for dependencies in the local environment",
     )
+    parser.add_argument(
+        "--skip-empty",
+        action="store_true",
+        help="skip packages with an empty PyPI links page",
+    )
     dep_source_args.add_argument(
         "-r",
         "--requirement",
@@ -255,7 +260,9 @@ def audit() -> None:
         if args.requirements is not None:
             req_files: List[Path] = [Path(req.name) for req in args.requirements]
             source = RequirementSource(
-                req_files, ResolveLibResolver(args.timeout, args.cache_dir, state), state
+                req_files,
+                ResolveLibResolver(args.timeout, args.cache_dir, state, args.skip_empty),
+                state,
             )
         else:
             source = PipSource(local=args.local, paths=args.paths)

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -176,7 +176,7 @@ def get_project_from_pypi(
     session, project, extras, timeout: Optional[int], state: AuditState
 ) -> Iterator[Candidate]:
     """Return candidates created from the project name and extras."""
-    url = "https://pypi.org/simple/{}".format(project)
+    url = "https://pypi.org/simple/{}/".format(project)
     response: requests.Response = session.get(url, timeout=timeout)
     if response.status_code == 404:
         raise PyPINotFoundError(f'Could not find project "{project}" on PyPI')


### PR DESCRIPTION
Adds a cli and resolvelib option to allow pip-audit continue running when resolvelib deems a package as unresolvable.
This notably happens when a package links page exists, but is empty (e.g. https://pypi.org/simple/pkg_resources/).
Fixes #210.

Nit: Avoid redirection from https://pypi.org/simple/PROJECT to https://pypi.org/simple/PROJECT/.