### PR TITLE
setup: Pin CycloneDX behind the 1.0.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "resolvelib>=0.8.0",
         "html5lib>=1.1",
         "CacheControl[filecache]>=0.12.10",
-        "cyclonedx-python-lib>=0.11.1",
+        "cyclonedx-python-lib>=0.11.1,<1.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
The v1.0.0 release included a breaking schema change.
```
pip_audit/_format/cyclonedx.py:36: error: List comprehension has incompatible type List[str]; expected List[VulnerabilityAdvisory]
Found 1 error in 1 file (checked 50 source files)
make: *** [lint] Error 1
```

The new advisory type requires a URL (which we don't have) so it wasn't immediately obvious what to do about this. So I'm proposing to pin our version behind 1.0.0 while we figure this out.