### PR TITLE
Simplify local development steps/guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: deps
-        run: make dev
       - name: lint
         run: make lint
       - name: test
@@ -40,8 +38,6 @@ jobs:
         # `argparse` between major versions.
         with:
           python-version: "3.6"
-      - name: deps
-        run: make dev
       - name: check-readme
         run: |
           diff \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         # `argparse` between major versions.
         with:
           python-version: "3.6"
+
+      - name: setup
+        run: make
+
       - name: check-readme
         run: |
           diff \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,6 @@ jobs:
 
       - uses: actions/setup-python@v2
 
-      - name: deps
-        run: make dev
-
       - name: docs
         run: |
           make doc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ but Windows and other supported platforms that are supported by Python
 should also work.
 
 If you're on a system that has GNU Make, you can use the convenience targets
-included in the `Makefile` that comes in the `pip-audit` repository. But this
-isn't required; all steps can be done without Make.
+included in the `Makefile` that comes in the `pip-audit` repository detailed
+below. But this isn't required; all steps can be done without Make.
 
 ## Development steps
 
@@ -26,60 +26,20 @@ git clone https://github.com/trailofbits/pip-audit
 cd pip-audit
 ```
 
-Then, set up the local development virtual environment.
+Then, use one of the `Makefile` targets to run a task. The first time this is
+run, this will also set up the local development virtual environment, and will
+install `pip-audit` as an editable package into this environment.
 
-If you have Make:
-
-```bash
-make dev
-source env/bin/active
-```
-
-Or, manually:
-
-```bash
-# assumes that `python` is Python 3; use `python3` if not
-python -m venv env
-source env/bin/activate
-pip install --upgrade pip
-pip install -e .[dev]
-```
-
-This will install `pip-audit` as an editable package into your local environment,
-which you can confirm from the command line:
-
-```bash
-pip-audit --version
-```
-
-If you see something like `pip-audit X.Y.Z`, then you're all done! Any changes
-you make to the `pip_audit` source tree will take effect immediately in your
-local environment.
-
-### Development practices
-
-Here are some guidelines to follow if you're working on a new feature or changes to
-`pip-audit`'s internal APIs:
-
-* *Keep the `pip-audit` APIs as private as possible*. Nearly all of `pip-audit`'s
-APIs should be private and treated as unstable and unsuitable for public use.
-If you're adding a new module to the source tree, prefix the filename with an underscore to
-emphasize that it's an internal (e.g., `pip_audit/_foo.py` instead of `pip_audit/foo.py`).
-
-* *Keep the CLI consistent with `pip`*. `pip-audit`'s CLI should *roughly* mirror that
-of `pip`. If you're adding a new flag or option to the CLI, check whether `pip` already
-has the same functionality (e.g., HTTP timeout control) and use the same short and long mnemonics.
-
-* *Perform judicious debug logging.* `pip-audit` uses the standard Python
-[`logging`](https://docs.python.org/3/library/logging.html) module. Use
-`logger.debug` early and often -- users who experience errors can submit better
-bug reports when their debug logs include helpful context!
-
-* *Update the [CHANGELOG](./CHANGELOG.md)*. If your changes are public or result
-in changes to `pip-audit`'s CLI, please record them under the "Unreleased" section,
-with an entry in an appropriate subsection ("Added", "Changed", "Removed", or "Fixed").
+Any changes you make to the `pip_audit` source tree will take effect
+immediately in the virtual environment.
 
 ### Linting
+
+You can lint locally with:
+
+```bash
+make lint
+```
 
 `pip-audit` is automatically linted and formatted with a collection of tools:
 
@@ -89,55 +49,25 @@ with an entry in an appropriate subsection ("Added", "Changed", "Removed", or "F
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage
 
-You can run all of the tools locally, either with Make:
-
-```bash
-make lint
-```
-
-...or manually:
-
-```bash
-# assumes that your virtual environment is active
-black pip_audit/ test/
-isort pip_audit/ test/
-flake8 pip_audit/ test/
-mypy pip_audit
-interrogate -c pyproject.toml .
-```
 
 ### Testing
+
+You can run the tests locally with:
+
+```bash
+make test
+```
+
+You can also filter by a pattern (uses `pytest -k`)
+
+```bash
+make test TESTS=test_audit_dry_run
+```
 
 `pip-audit` has a [`pytest`](https://docs.pytest.org/)-based unit test suite,
 including code coverage with [`coverage.py`](https://coverage.readthedocs.io/).
 
-You can run the tests locally, either with Make:
-
-```bash
-make test
-
-# filter by pattern (uses `pytest -k`)
-make test TESTS=test_audit_dry_run
-```
-
-...or manually:
-
-```bash
-# assumes that your virtual environment is active
-pytest --cov=pip_audit test/
-
-# optionally: fail if test coverage is not 100%
-python -m coverage report -m --fail-under 100
-```
-
 ### Documentation
-
-`pip-audit` uses [`pdoc3`](https://github.com/pdoc3/pdoc) to generate HTML documentation for
-the public Python APIs.
-
-Live documentation for the `main` branch is hosted
-[here](https://trailofbits.github.io/pip-audit/). Only the public APIs are
-documented, all undocumented APIs are **intentionally private and unstable.**
 
 If you're running Python 3.7 or newer, you can run the documentation build locally:
 
@@ -145,11 +75,12 @@ If you're running Python 3.7 or newer, you can run the documentation build local
 make doc
 ```
 
-...or manually:
+`pip-audit` uses [`pdoc3`](https://github.com/pdoc3/pdoc) to generate HTML documentation for
+the public Python APIs.
 
-```bash
-pdoc3 --force --html pip_audit
-```
+Live documentation for the `main` branch is hosted
+[here](https://trailofbits.github.io/pip-audit/). Only the public APIs are
+documented, all undocumented APIs are **intentionally private and unstable.**
 
 ### Releasing
 
@@ -180,3 +111,26 @@ RUN ME MANUALLY: git push origin main && git push origin vX.Y.Z
 ```
 
 Run that last command sequence to complete the release.
+
+## Development practices
+
+Here are some guidelines to follow if you're working on a new feature or changes to
+`pip-audit`'s internal APIs:
+
+* *Keep the `pip-audit` APIs as private as possible*. Nearly all of `pip-audit`'s
+APIs should be private and treated as unstable and unsuitable for public use.
+If you're adding a new module to the source tree, prefix the filename with an underscore to
+emphasize that it's an internal (e.g., `pip_audit/_foo.py` instead of `pip_audit/foo.py`).
+
+* *Keep the CLI consistent with `pip`*. `pip-audit`'s CLI should *roughly* mirror that
+of `pip`. If you're adding a new flag or option to the CLI, check whether `pip` already
+has the same functionality (e.g., HTTP timeout control) and use the same short and long mnemonics.
+
+* *Perform judicious debug logging.* `pip-audit` uses the standard Python
+[`logging`](https://docs.python.org/3/library/logging.html) module. Use
+`logger.debug` early and often -- users who experience errors can submit better
+bug reports when their debug logs include helpful context!
+
+* *Update the [CHANGELOG](./CHANGELOG.md)*. If your changes are public or result
+in changes to `pip-audit`'s CLI, please record them under the "Unreleased" section,
+with an entry in an appropriate subsection ("Added", "Changed", "Removed", or "Fixed").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,16 @@ You can run the tests locally with:
 make test
 ```
 
-You can also filter by a pattern (uses `pytest -k`)
+You can also filter by a pattern (uses `pytest -k`):
 
 ```bash
 make test TESTS=test_audit_dry_run
+```
+
+To test a specific file:
+
+```bash
+make test T=path/to/file.py
 ```
 
 `pip-audit` has a [`pytest`](https://docs.pytest.org/)-based unit test suite,

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ lint: env/pyvenv.cfg
 		interrogate -c pyproject.toml . && \
 		git diff --exit-code
 
-.PHONY: test
-test: env/pyvenv.cfg
+.PHONY: test tests
+test tests: env/pyvenv.cfg
 	. env/bin/activate && \
-		pytest --cov=pip_audit test/ $(TEST_ARGS) && \
+		pytest --cov=pip_audit $(T) $(TEST_ARGS) && \
 		python -m coverage report -m $(COV_ARGS)
 
 .PHONY: doc

--- a/Makefile
+++ b/Makefile
@@ -22,24 +22,23 @@ else
 	COV_ARGS := --fail-under 100
 endif
 
+env/pyvenv.cfg:
+	# Create our Python 3 virtual environment
+	rm -rf env
+	python3 -m venv env
+	./env/bin/python -m pip install --upgrade pip
+	./env/bin/python -m pip install -e .[dev]
+
 .PHONY: all
 all:
 	@echo "Run my targets individually!"
 
-.PHONY: dev
-dev:
-	test -d env || python3 -m venv env
-	. env/bin/activate && \
-		pip install --upgrade pip && \
-		pip install -e .[dev]
-
-
 .PHONY: run
-run:
+run: env/pyvenv.cfg
 	@. env/bin/activate && pip-audit $(ARGS)
 
 .PHONY: lint
-lint:
+lint: env/pyvenv.cfg
 	. env/bin/activate && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS) && \
@@ -49,24 +48,24 @@ lint:
 		git diff --exit-code
 
 .PHONY: test
-test:
+test: env/pyvenv.cfg
 	. env/bin/activate && \
 		pytest --cov=pip_audit test/ $(TEST_ARGS) && \
 		python -m coverage report -m $(COV_ARGS)
 
 .PHONY: doc
-doc:
+doc: env/pyvenv.cfg
 	. env/bin/activate && \
 		command -v pdoc3 && \
 		PYTHONWARNINGS='error::UserWarning' pdoc --force --html pip_audit
 
 .PHONY: package
-package:
+package: env/pyvenv.cfg
 	. env/bin/activate && \
 		python3 -m build
 
 .PHONY: release
-release:
+release: env/pyvenv.cfg
 	@. env/bin/activate && \
 		NEXT_VERSION=$$(bump $(BUMP_ARGS)) && \
 		git add pip_audit/_version.py && git diff --quiet --exit-code && \


### PR DESCRIPTION
This removes the need for a `make dev` target. It also simplifies `CONTRIBUTING.md` to make `make` a requirement and remove documentation of the 'manual' steps, since these will probably quickly become out of date over time. 