### PR TITLE
pip, _fix: Add missing CLI feedback

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -275,7 +275,7 @@ def audit() -> None:
                 req_files, ResolveLibResolver(args.timeout, args.cache_dir, state), state
             )
         else:
-            source = PipSource(local=args.local, paths=args.paths)
+            source = PipSource(local=args.local, paths=args.paths, state=state)
 
         # `--dry-run` only affects the auditor if `--fix` is also not supplied,
         # since the combination of `--dry-run` and `--fix` implies that the user
@@ -300,34 +300,36 @@ def audit() -> None:
                 pkg_count += 1
                 vuln_count += len(vulns)
 
-    # If the `--fix` flag has been applied, find a set of suitable fix versions and upgrade the
-    # dependencies at the source
-    fixes = list()
-    fixed_pkg_count = 0
-    fixed_vuln_count = 0
-    if args.fix:
-        for fix in resolve_fix_versions(service, result):
-            if args.dry_run:
-                if fix.is_skipped():
-                    fix = cast(SkippedFixVersion, fix)
-                    logger.info(
-                        f"Dry run: would have skipped {fix.dep.name} "
-                        f"upgrade because {fix.skip_reason}"
-                    )
-                else:
-                    fix = cast(ResolvedFixVersion, fix)
-                    logger.info(f"Dry run: would have upgraded {fix.dep.name} to " f"{fix.version}")
-                continue
+        # If the `--fix` flag has been applied, find a set of suitable fix versions and upgrade the
+        # dependencies at the source
+        fixes = list()
+        fixed_pkg_count = 0
+        fixed_vuln_count = 0
+        if args.fix:
+            for fix in resolve_fix_versions(service, result, state):
+                if args.dry_run:
+                    if fix.is_skipped():
+                        fix = cast(SkippedFixVersion, fix)
+                        logger.info(
+                            f"Dry run: would have skipped {fix.dep.name} "
+                            f"upgrade because {fix.skip_reason}"
+                        )
+                    else:
+                        fix = cast(ResolvedFixVersion, fix)
+                        logger.info(
+                            f"Dry run: would have upgraded {fix.dep.name} to " f"{fix.version}"
+                        )
+                    continue
 
-            if not fix.is_skipped():
-                fix = cast(ResolvedFixVersion, fix)
-                try:
-                    source.fix(fix)
-                    fixed_pkg_count += 1
-                    fixed_vuln_count += len(result[fix.dep])
-                except DependencySourceError as dse:
-                    fix = SkippedFixVersion(fix.dep, str(dse))
-            fixes.append(fix)
+                if not fix.is_skipped():
+                    fix = cast(ResolvedFixVersion, fix)
+                    try:
+                        source.fix(fix)
+                        fixed_pkg_count += 1
+                        fixed_vuln_count += len(result[fix.dep])
+                    except DependencySourceError as dse:
+                        fix = SkippedFixVersion(fix.dep, str(dse))
+                fixes.append(fix)
 
     # TODO(ww): Refine this: we should always output if our output format is an SBOM
     # or other manifest format (like the default JSON format).

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -328,7 +328,9 @@ def audit() -> None:
                         fixed_pkg_count += 1
                         fixed_vuln_count += len(result[fix.dep])
                     except DependencySourceError as dse:
-                        fix = SkippedFixVersion(fix.dep, str(dse))
+                        skip_reason = str(dse)
+                        logger.debug(skip_reason)
+                        fix = SkippedFixVersion(fix.dep, skip_reason)
                 fixes.append(fix)
 
     # TODO(ww): Refine this: we should always output if our output format is an SBOM

--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -94,6 +94,9 @@ class PipSource(DependencySource):
         """
         Fixes a dependency version in this `PipSource`.
         """
+        self.state.update_state(
+            f"Fixing {fix_version.dep.name} ({fix_version.dep.version} => {fix_version.version})"
+        )
         fix_cmd = [
             sys.executable,
             "-m",

--- a/pip_audit/_fix.py
+++ b/pip_audit/_fix.py
@@ -13,6 +13,7 @@ from pip_audit._service import (
     VulnerabilityResult,
     VulnerabilityService,
 )
+from pip_audit._state import AuditState
 
 
 @dataclass(frozen=True)
@@ -57,7 +58,9 @@ class SkippedFixVersion(FixVersion):
 
 
 def resolve_fix_versions(
-    service: VulnerabilityService, result: Dict[Dependency, List[VulnerabilityResult]]
+    service: VulnerabilityService,
+    result: Dict[Dependency, List[VulnerabilityResult]],
+    state: AuditState = AuditState(),
 ) -> Iterator[FixVersion]:
     """
     Resolves a mapping of dependencies to known vulnerabilities to a series of fix versions without
@@ -70,14 +73,17 @@ def resolve_fix_versions(
             continue
         dep = cast(ResolvedDependency, dep)
         try:
-            version = _resolve_fix_version(service, dep, vulns)
+            version = _resolve_fix_version(service, dep, vulns, state)
             yield ResolvedFixVersion(dep, version)
         except FixResolutionImpossible as fri:
             yield SkippedFixVersion(dep, str(fri))
 
 
 def _resolve_fix_version(
-    service: VulnerabilityService, dep: ResolvedDependency, vulns: List[VulnerabilityResult]
+    service: VulnerabilityService,
+    dep: ResolvedDependency,
+    vulns: List[VulnerabilityResult],
+    state: AuditState,
 ) -> Version:
     # We need to upgrade to a fix version that satisfies all vulnerability results
     #
@@ -87,6 +93,7 @@ def _resolve_fix_version(
     current_version = dep.version
     current_vulns = vulns
     while current_vulns:
+        state.update_state(f"Resolving fix version for {dep.name}, checking {current_version}")
 
         def get_earliest_fix_version(d: ResolvedDependency, v: VulnerabilityResult) -> Version:
             for fix_version in v.fix_versions:

--- a/pip_audit/_fix.py
+++ b/pip_audit/_fix.py
@@ -2,6 +2,7 @@
 Functionality for resolving fixed versions of dependencies.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, Iterator, List, cast
 
@@ -14,6 +15,8 @@ from pip_audit._service import (
     VulnerabilityService,
 )
 from pip_audit._state import AuditState
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -76,7 +79,9 @@ def resolve_fix_versions(
             version = _resolve_fix_version(service, dep, vulns, state)
             yield ResolvedFixVersion(dep, version)
         except FixResolutionImpossible as fri:
-            yield SkippedFixVersion(dep, str(fri))
+            skip_reason = str(fri)
+            logger.debug(skip_reason)
+            yield SkippedFixVersion(dep, skip_reason)
 
 
 def _resolve_fix_version(


### PR DESCRIPTION
I purposely didn't add anything to the `CHANGELOG` since `--fix` hasn't been included in a released version yet.