### PR TITLE
_virtual_env: Pipe installation output to /dev/null

### DIFF
--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -102,7 +102,12 @@ class VirtualEnv(venv.EnvBuilder):
             *self._install_args,
         ]
         try:
-            subprocess.run(package_install_cmd, check=True)
+            subprocess.run(
+                package_install_cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
         except subprocess.CalledProcessError as cpe:
             raise VirtualEnvError(f"Failed to install packages: {package_install_cmd}") from cpe
 


### PR DESCRIPTION
As part of a8f9fa2b9266f65cdf2efa33ca8c62903370765f, we stopped piping the package installation output and instead let it show up in stdout which messes with our CLI spinner. Let's pass in `subprocess.DEVNULL` again.