### PR TITLE
Makefile: predicate venv on setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 	COV_ARGS := --fail-under 100
 endif
 
-env/pyvenv.cfg:
+env/pyvenv.cfg: setup.py
 	# Create our Python 3 virtual environment
 	rm -rf env
 	python3 -m venv env


### PR DESCRIPTION
This makes it easier to perform local development after merging changes to dependencies. `setup.py` doesn't change frequently during routine development, so this shouldn't regularly incur any additional development-time overhead.