### PR TITLE
pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.6.0
+    hooks:
+    -   id: autopep8

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "mypy",
             "types-requests",
             "types-html5lib",
+            "pre-commit",
         ]
     },
     classifiers=[


### PR DESCRIPTION
added `.pre-commit-config.yaml`.

tldr usage:
set up the git hook scripts: `pre-commit install`, and this will run when `git commit`.

extra:
can use 
`pre-commit run <hook> --files <file>` to run just this hook on just this file.
`pre-commit run -a` (short for `--all-files`). 
`pre-commit autoupdate` to update all rev's in the yaml

(closes #252) 