### PR TITLE
Add Pre-Commit Hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: pip-audit
+  name: pip-audit
+  description: "Audits Python environments and dependency trees for known vulnerabilities"
+  entry: pip-audit
+  pass_filenames: false
+  language: python

--- a/README.md
+++ b/README.md
@@ -303,6 +303,20 @@ and purposes, `pip-audit -r INPUT` is functionally equivalent to
 `pip install -r INPUT`, with a small amount of **non-security isolation** to
 avoid conflicts with any of your local environments.
 
+## pre-commit support
+
+pip-audit has [pre-commit](https://pre-commit.com/) support. Please specify your
+arguments in your pre-commit config. An example config using requirements file can be:
+
+```yaml
+  - repo: https://github.com/trailofbits/pip-audit
+    rev: v2.1.2
+    hooks:
+      -   id: pip-audit
+          args: ["-r", "requirements.txt"]
+```
+- Any valid CLI arguments documented above can be passed.
+
 ## Licensing
 
 `pip-audit` is licensed under the Apache 2.0 License.


### PR DESCRIPTION
- Add a pip-audit pre-commit hook
- Use the `pass_filenames: false` so user has to specify args
- Add section with example usage to README.md

Test:
- Run with bandersnatch pre-commit pointed @ https://github.com/cooperlees/pip-audit
```shell
cooper-mbp:bandersnatch cooper$ ~/venvs/bs/bin/pre-commit run -a
[INFO] Initializing environment for git@github.com:cooperlees/pip-audit.git.
[INFO] Installing environment for git@github.com:cooperlees/pip-audit.git.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
...
pip-audit................................................................Passed
```

Fixes #252