### PR TITLE
Add that pip-aduit does not work in pre-commit.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ arguments in your pre-commit config. An example config using requirements file c
     hooks:
       -   id: pip-audit
           args: ["-r", "requirements.txt"]
+
+ci:
+  # Leave pip-audit to only run locally and not in CI
+  # pre-commit.ci does not allow network calls
+  skip: [pip-audit]
 ```
 - Any valid CLI arguments documented above can be passed.
 


### PR DESCRIPTION
- pre-commit.ci blocks network connections / pip
- So share this knowledge and config to skip it into README so others don't get suprised like I did
Test: https://github.com/pypa/bandersnatch/pull/1116