### PR TITLE
service/pypi: fix version parsing when enforcing hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* A bug introduced with a previous fix to version parsing ([#263]) was
+  fixed ([#264](https://github.com/trailofbits/pip-audit/pull/264))
+
 ## [2.2.0] - 2022-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All versions prior to 0.0.9 are untracked.
 
 ### Fixed
 
-* A bug introduced with a previous fix to version parsing ([#263]) was
+* A bug introduced with a previous fix to version parsing
+  ([#263](https://github.com/trailofbits/pip-audit/pull/263)) was
   fixed ([#264](https://github.com/trailofbits/pip-audit/pull/264))
 
 ## [2.2.0] - 2022-05-02

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, cast
 
 import requests
-from packaging.version import InvalidVersion, Version
+from packaging.version import InvalidVersion, Version, parse
 
 from pip_audit._cache import caching_session
 from pip_audit._service.interface import (
@@ -72,7 +72,9 @@ class PyPIService(VulnerabilityService):
 
         # If the dependency has a hash explicitly listed, check it against the PyPI data
         if spec.hashes:
-            releases = {Version(k): v for k, v in response_json["releases"].items()}
+            # NOTE: We use `parse(...)` instead of `Version(...)` because PyPI
+            # has lots of releases with legacy versions.
+            releases = {parse(k): v for k, v in response_json["releases"].items()}
             release = releases.get(spec.version)
             if release is None:
                 raise ServiceError(

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -268,3 +268,67 @@ def test_pypi_hashed_dep_no_release_data(cache_dir, monkeypatch):
     dep = service.ResolvedDependency("foo", Version("1.0"), hashes={"sha256": ["package-hash"]})
     with pytest.raises(service.ServiceError):
         dict(pypi.query_all(iter([dep])))
+
+
+def test_pypi_legacy_release_versions_do_not_crash(cache_dir, monkeypatch):
+    def get_mock_response():
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "releases": {
+                        # Sampled from real invalid ("legacy") versions on PyPI
+                        "0.8.0-final0": [],
+                        "0.1-bulbasaur": [],
+                        "0.8d": [],
+                        "2004d": [],
+                        "0.5.2.5.g5b3e942": [],
+                        "git-unknown": [],
+                        "0.7.1.fix1": [],
+                        "r1": [],
+                        "0.1.0.1.g46ab6a7": [],
+                        "1.8.-1": [],
+                        "9bbb4f3": [],
+                        "2.0.0-final": [],
+                        "2013-02-16": [],
+                        "1.0beta5prerelease": [],
+                        "1.1.0-2-g555364d-dirty": [],
+                        "0.2-test1": [],
+                        "1.2.dev-r25": [],
+                        # Some valid PEP 440 versions for good measure
+                        "0.8.0rc1": [],
+                        "0.9.0": [],
+                        "1.0.0": [{"digests": {"sha256": "fakesha"}}],
+                    },
+                    "vulnerabilities": [
+                        {
+                            "id": "VULN-0",
+                            "details": "The first vulnerability",
+                            "fixed_in": ["1.1"],
+                            "aliases": [],
+                        }
+                    ],
+                }
+
+        return MockResponse()
+
+    monkeypatch.setattr(
+        service.pypi, "caching_session", lambda _: get_mock_session(get_mock_response)
+    )
+
+    pypi = service.PyPIService(cache_dir)
+    dep = service.ResolvedDependency("foo", Version("1.0"), hashes={"sha256": ["fakesha"]})
+    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+        pypi.query_all(iter([dep]))
+    )
+    assert len(results) == 1
+    assert dep in results
+    assert len(results[dep]) == 1
+    assert results[dep][0] == service.VulnerabilityResult(
+        id="VULN-0",
+        description="The first vulnerability",
+        fix_versions=[Version("1.1")],
+        aliases=set(),
+    )


### PR DESCRIPTION
Fixes the fix in #263. This time, I'm going to add unit tests.