### PR TITLE
ci(pre-commit): remove setup-cfg-fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,6 @@ repos:
         args: [--markdown-linebreak-ext=md]
       - id: no-commit-to-branch
         args: ["-b", "main"]
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
-    hooks:
-      - id: setup-cfg-fmt
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
setuptools config was moved to pyproject.toml