### PR TITLE
pip_audit: ratchet down typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ endif
 
 env/pyvenv.cfg: setup.py pyproject.toml
 	# Create our Python 3 virtual environment
-	rm -rf env
-	python3 -m venv env
+	[[ ! -d env ]] || python3 -m venv env
 	./env/bin/python -m pip install --upgrade pip
 	./env/bin/python -m pip install -e .[dev]
 
@@ -47,7 +46,7 @@ lint: env/pyvenv.cfg
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS) && \
 		flake8 $(ALL_PY_SRCS) && \
-		mypy $(PY_MODULE) test/ && \
+		mypy $(PY_MODULE) && \
 		interrogate -c pyproject.toml .
 
 .PHONY: test tests

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,0 @@
-[mypy]
-warn_return_any = True
-warn_unused_configs = True
-warn_unused_ignores = True
-warn_no_return = True
-strict_equality = True
-allow_redefinition = True
-check_untyped_defs = True
-show_error_codes = True

--- a/pip_audit/_cache.py
+++ b/pip_audit/_cache.py
@@ -12,8 +12,8 @@ from typing import Any, Optional
 
 import pip_api
 import requests
-from cachecontrol import CacheControl  # type: ignore
-from cachecontrol.caches import FileCache  # type: ignore
+from cachecontrol import CacheControl
+from cachecontrol.caches import FileCache
 from packaging.version import Version
 
 from pip_audit._service.interface import ServiceError
@@ -74,7 +74,7 @@ class _SafeFileCache(FileCache):
     caching directory as a running `pip` process).
     """
 
-    def __init__(self, directory):
+    def __init__(self, directory: Path):
         self._logged_warning = False
         super().__init__(directory)
 
@@ -134,7 +134,7 @@ class _SafeFileCache(FileCache):
                 self._logged_warning = True
 
 
-def caching_session(cache_dir: Optional[Path], *, use_pip=False) -> CacheControl:
+def caching_session(cache_dir: Optional[Path], *, use_pip: bool = False) -> CacheControl:
     """
     Return a `requests` style session, with suitable caching middleware.
 

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -56,7 +56,7 @@ class OutputFormatChoice(str, enum.Enum):
         else:
             assert_never(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -77,7 +77,7 @@ class VulnerabilityServiceChoice(str, enum.Enum):
         else:
             assert_never(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -101,7 +101,7 @@ class VulnerabilityDescriptionChoice(str, enum.Enum):
         else:
             assert_never(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -117,7 +117,7 @@ class ProgressSpinnerChoice(str, enum.Enum):
     def __bool__(self) -> bool:
         return self is ProgressSpinnerChoice.On
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -6,24 +6,25 @@ authors under the ISC license.
 """
 
 import itertools
-from email.message import EmailMessage
+from email.message import EmailMessage, Message
 from email.parser import BytesParser
 from io import BytesIO
 from operator import attrgetter
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import BinaryIO, Iterator, List, Optional, Set, cast
+from typing import Any, BinaryIO, Iterator, List, Mapping, Optional, Set, Union, cast
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
 import html5lib
 import requests
-from cachecontrol import CacheControl  # type: ignore
+from cachecontrol import CacheControl
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name, parse_sdist_filename, parse_wheel_filename
 from packaging.version import Version
 from resolvelib.providers import AbstractProvider
+from resolvelib.resolvers import RequirementInformation
 
 from pip_audit._cache import caching_session
 from pip_audit._state import AuditState
@@ -68,10 +69,10 @@ class Candidate:
         self._timeout = timeout
         self._state = state
 
-        self._metadata: Optional[EmailMessage] = None
+        self._metadata: Optional[Message] = None
         self._dependencies: Optional[List[Requirement]] = None
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         """
         A string representation for `Candidate`.
         """
@@ -80,7 +81,7 @@ class Candidate:
         return f"<{self.name}[{','.join(self.extras)}]=={self.version} wheel={self.is_wheel}>"
 
     @property
-    def metadata(self) -> EmailMessage:
+    def metadata(self) -> Message:
         """
         Return the package metadata for this candidate.
         """
@@ -94,7 +95,7 @@ class Candidate:
                 self._metadata = self._get_metadata_for_sdist()
         return self._metadata
 
-    def _get_dependencies(self):
+    def _get_dependencies(self) -> Iterator[Requirement]:
         """
         Computes the dependency set for this candidate.
         """
@@ -119,7 +120,7 @@ class Candidate:
             self._dependencies = list(self._get_dependencies())
         return self._dependencies
 
-    def _get_metadata_for_wheel(self):
+    def _get_metadata_for_wheel(self) -> Message:
         """
         Extracts the metadata for this candidate, if it's a wheel.
         """
@@ -138,7 +139,7 @@ class Candidate:
         # If we didn't find the metadata, return an empty dict
         return EmailMessage()  # pragma: no cover
 
-    def _get_metadata_for_sdist(self):
+    def _get_metadata_for_sdist(self) -> Message:
         """
         Extracts the metadata for this candidate, if it's a source distribution.
         """
@@ -173,7 +174,12 @@ class Candidate:
 
 
 def get_project_from_indexes(
-    index_urls: List[str], session, project, extras, timeout: Optional[int], state: AuditState
+    index_urls: List[str],
+    session: CacheControl,
+    project: str,
+    extras: Set[str],
+    timeout: Optional[int],
+    state: AuditState,
 ) -> Iterator[Candidate]:
     """Return candidates from all indexes created from the project name and extras."""
     project_found = False
@@ -192,7 +198,12 @@ def get_project_from_indexes(
 
 
 def get_project_from_index(
-    index_url: str, session, project, extras, timeout: Optional[int], state: AuditState
+    index_url: str,
+    session: CacheControl,
+    project: str,
+    extras: Set[str],
+    timeout: Optional[int],
+    state: AuditState,
 ) -> Iterator[Candidate]:
     """Return candidates from an index created from the project name and extras."""
     url = index_url + "/" + project
@@ -272,19 +283,32 @@ class PyPIProvider(AbstractProvider):
         self.session = caching_session(cache_dir, use_pip=True)
         self._state = state
 
-    def identify(self, requirement_or_candidate):
+    def identify(self, requirement_or_candidate: Union[Requirement, Candidate]) -> str:
         """
         See `resolvelib.providers.AbstractProvider.identify`.
         """
         return canonicalize_name(requirement_or_candidate.name)
 
-    def get_preference(self, identifier, resolutions, candidates, information, backtrack_causes):
+    # TODO: Typing. See: https://github.com/sarugaku/resolvelib/issues/104
+    def get_preference(  # type: ignore[override, no-untyped-def]
+        self,
+        identifier: Any,
+        resolutions: Mapping[Any, Any],
+        candidates: Mapping[Any, Iterator[Any]],
+        information: Mapping[Any, Iterator[RequirementInformation[Any, Any]]],
+        backtrack_causes: Any,
+    ):
         """
         See `resolvelib.providers.AbstractProvider.get_preference`.
         """
         return sum(1 for _ in candidates[identifier])
 
-    def find_matches(self, identifier, requirements, incompatibilities):
+    def find_matches(
+        self,
+        identifier: Any,
+        requirements: Mapping[Any, Iterator[Any]],
+        incompatibilities: Mapping[Any, Iterator[Any]],
+    ) -> Iterator[Any]:
         """
         See `resolvelib.providers.AbstractProvider.find_matches`.
         """
@@ -333,13 +357,13 @@ class PyPIProvider(AbstractProvider):
             else:
                 yield from candidates
 
-    def is_satisfied_by(self, requirement, candidate):
+    def is_satisfied_by(self, requirement: Any, candidate: Any) -> bool:
         """
         See `resolvelib.providers.AbstractProvider.is_satisfied_by`.
         """
         return candidate.version in requirement.specifier
 
-    def get_dependencies(self, candidate):
+    def get_dependencies(self, candidate: Any) -> Any:
         """
         See `resolvelib.providers.AbstractProvider.get_dependencies`.
         """

--- a/pip_audit/_dependency_source/resolvelib/pypi_provider.py
+++ b/pip_audit/_dependency_source/resolvelib/pypi_provider.py
@@ -295,7 +295,7 @@ class PyPIProvider(AbstractProvider):
         identifier: Any,
         resolutions: Mapping[Any, Any],
         candidates: Mapping[Any, Iterator[Any]],
-        information: Mapping[Any, Iterator[RequirementInformation[Any, Any]]],
+        information: Mapping[Any, Iterator[RequirementInformation]],
         backtrack_causes: Any,
     ):
         """

--- a/pip_audit/_dependency_source/resolvelib/resolvelib.py
+++ b/pip_audit/_dependency_source/resolvelib/resolvelib.py
@@ -5,9 +5,9 @@ Resolve a list of dependencies via the `resolvelib` API as well as a custom
 
 import logging
 from pathlib import Path
-from typing import List, Optional, cast
+from typing import List, Optional, Union
 
-from packaging.requirements import Requirement
+from packaging.requirements import Requirement as _Requirement
 from pip_api import Requirement as ParsedRequirement
 from requests.exceptions import HTTPError
 from resolvelib import BaseReporter, Resolver
@@ -21,6 +21,9 @@ from .pypi_provider import PyPINotFoundError, PyPIProvider
 logger = logging.getLogger(__name__)
 
 PYPI_URL = "https://pypi.org/simple"
+
+
+Requirement = Union[_Requirement, ParsedRequirement]
 
 
 class ResolveLibResolver(DependencyResolver):
@@ -62,7 +65,6 @@ class ResolveLibResolver(DependencyResolver):
         # since the latter is a subclass. But only the latter knows whether the
         # requirement is editable, so we need to check for it here.
         if isinstance(req, ParsedRequirement):
-            req = cast(ParsedRequirement, req)
             if req.editable and self._skip_editable:
                 return [
                     SkippedDependency(name=req.name, skip_reason="requirement marked as editable")

--- a/pip_audit/_fix.py
+++ b/pip_audit/_fix.py
@@ -4,7 +4,7 @@ Functionality for resolving fixed versions of dependencies.
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Iterator, List, cast
+from typing import Any, Dict, Iterator, List, cast
 
 from packaging.version import Version
 
@@ -29,7 +29,7 @@ class FixVersion:
 
     dep: ResolvedDependency
 
-    def __init__(self, *_args, **_kwargs) -> None:  # pragma: no cover
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
         """
         A stub constructor that always fails.
         """

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -41,7 +41,7 @@ class ColumnsFormat(VulnerabilityFormat):
         self.output_desc = output_desc
 
     @property
-    def is_manifest(self):
+    def is_manifest(self) -> bool:
         """
         See `VulnerabilityFormat.is_manifest`.
         """

--- a/pip_audit/_format/cyclonedx.py
+++ b/pip_audit/_format/cyclonedx.py
@@ -69,7 +69,7 @@ class CycloneDxFormat(VulnerabilityFormat):
         self._inner_format = inner_format
 
     @property
-    def is_manifest(self):
+    def is_manifest(self) -> bool:
         """
         See `VulnerabilityFormat.is_manifest`.
         """

--- a/pip_audit/_format/json.py
+++ b/pip_audit/_format/json.py
@@ -27,7 +27,7 @@ class JsonFormat(VulnerabilityFormat):
         self.output_desc = output_desc
 
     @property
-    def is_manifest(self):
+    def is_manifest(self) -> bool:
         """
         See `VulnerabilityFormat.is_manifest`.
         """

--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, Iterator, List, Set, Tuple
+from typing import Any, Dict, Iterator, List, Set, Tuple
 
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -28,7 +28,7 @@ class Dependency:
     Use the `canonicalized_name` property when a canonicalized form is necessary.
     """
 
-    def __init__(self, *_args, **_kwargs) -> None:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
         """
         A stub constructor that always fails.
         """

--- a/pip_audit/_state.py
+++ b/pip_audit/_state.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from logging.handlers import MemoryHandler
 from typing import Any, Dict, List, Sequence
 
-from progress.spinner import Spinner as BaseSpinner  # type: ignore
+from progress.spinner import Spinner as BaseSpinner
 
 
 class AuditState:
@@ -30,7 +30,7 @@ class AuditState:
 
         self._members = members
 
-    def update_state(self, message: str):
+    def update_state(self, message: str) -> None:
         """
         Called whenever `pip_audit`'s internal state changes in a way that's meaningful to
         expose to a user.
@@ -64,7 +64,9 @@ class AuditState:
         self.initialize()
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _exc_traceback):  # pragma: no cover
+    def __exit__(
+        self, _exc_type: Any, _exc_value: Any, _exc_traceback: Any
+    ) -> None:  # pragma: no cover
         """
         Helper to ensure `finalize` gets called when the `pip-audit` state falls out of scope of a
         `with` statement.
@@ -122,7 +124,7 @@ class AuditSpinner(_StateActor, BaseSpinner):  # pragma: no cover
         )
         self.prev_handlers: List[logging.Handler] = []
 
-    def _writeln_truncated(self, line: str):
+    def _writeln_truncated(self, line: str) -> None:
         """
         Wraps `BaseSpinner.writeln`, providing reasonable truncation behavior
         when a line would otherwise overflow its terminal row and cause the progress

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -5,6 +5,7 @@ Create virtual environments with a custom set of packages and inspect their depe
 import json
 import logging
 import venv
+from types import SimpleNamespace
 from typing import Iterator, List, Optional, Tuple
 
 from packaging.version import Version
@@ -54,7 +55,7 @@ class VirtualEnv(venv.EnvBuilder):
         self._packages: Optional[List[Tuple[str, Version]]] = None
         self._state = state
 
-    def post_setup(self, context):
+    def post_setup(self, context: SimpleNamespace) -> None:
         """
         Install the custom package and populate the list of installed packages.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,19 @@ omit = ["pip_audit/_cli.py"]
 exclude = ["setup.py", "env", "test", "pip_audit/_cli.py", "pip_audit/_version.py"]
 ignore-semiprivate = true
 fail-under = 100
+
+[tool.mypy]
+allow_redefinition = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_optional = true
+show_error_codes = true
+strict_equality = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true


### PR DESCRIPTION
This ratchets down our typing some more, and moves our Mypy configuration into `pyproject.toml` (removing another top-level config file.)

Doing this also helped us catch a typing bug in `resolvelib`: https://github.com/sarugaku/resolvelib/issues/104