### PR TITLE
cli: allow ignoring specific vulnerability IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 All versions prior to 0.0.9 are untracked.
 
+## [Unreleased]
+
+### Added
+
+* CLI: The `--ignore-vuln` option has been added, allowing users to
+  specify vulnerability IDs to ignore during the final report.
+  ([#275](https://github.com/trailofbits/pip-audit/pull/275))
+
 ## [2.2.1] - 2022-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ usage: pip-audit [-h] [-V] [-l] [-r REQUIREMENTS] [-f FORMAT] [-s SERVICE]
                  [--path PATHS] [-v] [--fix] [--require-hashes]
                  [--index-url INDEX_URL] [--extra-index-url EXTRA_INDEX_URLS]
                  [--skip-editable] [--no-deps] [-o FILE]
+                 [--ignore-vuln IGNORE_VULNS]
                  [project_path]
 
 audit the Python environment for dependencies with known vulnerabilities
@@ -142,6 +143,9 @@ optional arguments:
                         False)
   -o FILE, --output FILE
                         output results to the given file (default: None)
+  --ignore-vuln IGNORE_VULNS
+                        ignore a specific vulnerability by its vulnerability
+                        ID (default: [])
 ```
 <!-- @end-pip-audit-help@ -->
 

--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -114,6 +114,12 @@ class VulnerabilityResult:
             self.id, self.description, self.fix_versions, self.aliases | other.aliases - {self.id}
         )
 
+    def has_any_id(self, ids: Set[str]) -> bool:
+        """
+        Returns whether ids intersects with {id} | aliases.
+        """
+        return bool(ids & (self.aliases | {self.id}))
+
 
 class VulnerabilityService(ABC):
     """

--- a/test/service/test_interface.py
+++ b/test/service/test_interface.py
@@ -62,3 +62,14 @@ def test_vulnerability_result_update_aliases():
     merged = result1.merge_aliases(result2)
     assert merged.id == "FOO"
     assert merged.aliases == {"BAR", "BAZ", "ZAP", "QUUX"}
+
+
+def test_vulnerability_result_has_any_id():
+    result = VulnerabilityResult(
+        id="FOO", description="bar", fix_versions=[Version("1.0.0")], aliases={"BAR", "BAZ", "QUUX"}
+    )
+
+    assert result.has_any_id({"FOO"})
+    assert result.has_any_id({"ham", "eggs", "BAZ"})
+    assert not result.has_any_id({"zilch"})
+    assert not result.has_any_id(set())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,9 +10,12 @@ import pip_audit._cli
         ([], 1, 1, "Found 1 known vulnerability in 1 package"),
         ([], 2, 1, "Found 2 known vulnerabilities in 1 package"),
         ([], 2, 2, "Found 2 known vulnerabilities in 2 packages"),
+        (["--ignore-vuln", "bar"], 2, 2, "Found 2 known vulnerabilities, ignored 1 in 2 packages"),
         (["--fix"], 1, 1, "fixed 1 vulnerability in 1 package"),
         (["--fix"], 2, 1, "fixed 2 vulnerabilities in 1 package"),
         (["--fix"], 2, 2, "fixed 2 vulnerabilities in 2 packages"),
+        ([], 0, 0, "No known vulnerabilities found"),
+        (["--ignore-vuln", "bar"], 0, 1, "No known vulnerabilities found, 1 ignored"),
     ],
 )
 def test_plurals(capsys, monkeypatch, args, vuln_count, pkg_count, expected):
@@ -30,10 +33,14 @@ def test_plurals(capsys, monkeypatch, args, vuln_count, pkg_count, expected):
                 canonical_name="something" + str(i),
                 version=1,
             ),
-            [pretend.stub(fix_versions=[2], id="foo")] * (vuln_count // pkg_count),
+            [pretend.stub(fix_versions=[2], id="foo", aliases=set(), has_any_id=lambda x: False)]
+            * (vuln_count // pkg_count),
         )
         for i in range(pkg_count)
     ]
+
+    if "--ignore-vuln" in args:
+        result[0][1].append(pretend.stub(id="bar", aliases=set(), has_any_id=lambda x: True))
 
     auditor = pretend.stub(audit=lambda a: result)
     monkeypatch.setattr(pip_audit._cli, "Auditor", lambda *a, **kw: auditor)


### PR DESCRIPTION
This commit introduces a new flag to pip-audit's CLI (--ignore-vuln)
that takes a string representing a vulnerability id, if any of the
packages scanned detect said vulnerability, it will be ignored in the
final report.

This allows users of pip-audit to ignore certain vulnerabilities that
they may deem not exploitable for whatever reason.

The flag can be used multiple times to ignore multiple vulnerabilities.

Closes #245