### PR TITLE
state: ensure that cursor is revealed when spinner exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* CLI: A bug causing the terminal's cursor to disappear on some
+  versions of CPython was fixed
+  ([#280](https://github.com/trailofbits/pip-audit/issues/280))
+
 ## [2.3.0] - 2022-05-18
 
 ### Added

--- a/pip_audit/_state.py
+++ b/pip_audit/_state.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from logging.handlers import MemoryHandler
 from typing import Any, Dict, List, Sequence
 
+from progress import SHOW_CURSOR
 from progress.spinner import Spinner as BaseSpinner
 
 
@@ -163,6 +164,11 @@ class AuditSpinner(_StateActor, BaseSpinner):  # pragma: no cover
         """
         self.writeln("")
         self.file.write("\r")
+
+        # `BaseSpinner` normally re-reveals the cursor as part of `finish()` or
+        # `__del__`, but we override `finish()` and `__del__` isn't reliably
+        # invoked on context exit. So we do it manually here.
+        self.file.write(SHOW_CURSOR)
         self.file.flush()
 
     def update_state(self, message: str) -> None:


### PR DESCRIPTION
Fixes #280.

Signed-off-by: William Woodruff <william@trailofbits.com>