### PR TITLE
cli, state: replace `progress` spinner with `rich.status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* CLI: `pip-audit`'s progress spinner has been refactored to make it
+  faster and more responsive
+  ([#283](https://github.com/trailofbits/pip-audit/pull/283))
+
 ## [2.3.1] - 2022-05-24
 
 ### Fixed

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -360,7 +360,7 @@ def audit() -> None:
     with ExitStack() as stack:
         actors = []
         if args.progress_spinner:
-            actors.append(AuditSpinner())
+            actors.append(AuditSpinner("Collecting inputs"))
         state = stack.enter_context(AuditState(members=actors))
 
         source: DependencySource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
     "html5lib>=1.1",
     "packaging>=21.0.0",
     "pip-api>=0.0.28",
-    "progress>=1.6",
     "resolvelib>=0.8.0",
+    "rich>=12.4",
 ]
 requires-python = ">=3.7"
 


### PR DESCRIPTION
This simplifies the spinner implementation quite a bit, and brings us slightly closer in line with `pip`'s already vendored dependencies.

Closes #282.

Signed-off-by: William Woodruff <william@trailofbits.com>

