### PR TITLE
osv: fix incorrect schema assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All versions prior to 0.0.9 are untracked.
   faster and more responsive
   ([#283](https://github.com/trailofbits/pip-audit/pull/283))
 
+### Fixed
+
+* Vulnerability sources: a bug stemming from an incorrect assumption
+  about OSV's schema guarantees was fixed
+  ([#284](https://github.com/trailofbits/pip-audit/pull/284))
+
 ## [2.3.1] - 2022-05-24
 
 ### Fixed

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -89,9 +89,7 @@ class OsvService(VulnerabilityService):
             if description is None:
                 description = "N/A"
 
-            aliases = set()
-            if "aliases" in vuln:
-                aliases.update(vuln["aliases"])
+            aliases = set(vuln.get("aliases", []))
 
             # OSV doesn't mandate this field either. There's very little we
             # can do without it, so we skip any results that are missing it.

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -3,6 +3,7 @@ Functionality for using the [OSV](https://osv.dev/) API as a `VulnerabilityServi
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import List, Optional, Tuple, cast
 
@@ -17,6 +18,8 @@ from pip_audit._service.interface import (
     VulnerabilityResult,
     VulnerabilityService,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OsvService(VulnerabilityService):
@@ -77,10 +80,28 @@ class OsvService(VulnerabilityService):
 
         for vuln in response_json["vulns"]:
             id = vuln["id"]
-            description = vuln["details"]
-            aliases = set(vuln["aliases"])
+
+            # The summary is intended to be shorter, so we prefer it over
+            # details, if present. However, neither is required.
+            description = vuln.get("summary")
+            if description is None:
+                description = vuln.get("details")
+            if description is None:
+                description = "N/A"
+
+            aliases = set()
+            if "aliases" in vuln:
+                aliases.update(vuln["aliases"])
+
+            # OSV doesn't mandate this field either. There's very little we
+            # can do without it, so we skip any results that are missing it.
+            affecteds = vuln.get("affected")
+            if affecteds is None:
+                logger.warning(f"OSV vuln entry '{id}' is missing 'affected' list")
+                continue
+
             fix_versions: List[Version] = []
-            for affected in vuln["affected"]:
+            for affected in affecteds:
                 pkg = affected["package"]
                 # We only care about PyPI versions
                 if pkg["name"] == spec.canonical_name and pkg["ecosystem"] == "PyPI":


### PR DESCRIPTION
We shouldn't assume that any fields other than `id`
or `modified` exist, and we currently don't check the latter.

Signed-off-by: William Woodruff <william@trailofbits.com>