### PR TITLE
cli, service: better error handling for connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All versions prior to 0.0.9 are untracked.
   faster and more responsive
   ([#283](https://github.com/trailofbits/pip-audit/pull/283))
 
+* CLI, Vulnerability sources: the error message used to report
+  connection failures to vulnerability sources was improved
+  ([#287](https://github.com/trailofbits/pip-audit/pull/287))
+
 ### Fixed
 
 * Vulnerability sources: a bug stemming from an incorrect assumption

--- a/pip_audit/_service/__init__.py
+++ b/pip_audit/_service/__init__.py
@@ -3,6 +3,7 @@ Vulnerability service interfaces and implementations for `pip-audit`.
 """
 
 from .interface import (
+    ConnectionError,
     Dependency,
     ResolvedDependency,
     ServiceError,
@@ -14,6 +15,7 @@ from .osv import OsvService
 from .pypi import PyPIService
 
 __all__ = [
+    "ConnectionError",
     "Dependency",
     "ResolvedDependency",
     "ServiceError",

--- a/pip_audit/_service/interface.py
+++ b/pip_audit/_service/interface.py
@@ -158,3 +158,12 @@ class ServiceError(Exception):
     """
 
     pass
+
+
+class ConnectionError(ServiceError):
+    """
+    A specialization of `ServiceError` specifically for cases where the
+    vulnerability service is unreachable or offline.
+    """
+
+    pass


### PR DESCRIPTION
These can occur if the user is behind a corporate firewall
or other network policy that blocks access to PyPI,
or in the unlikely event of a PyPI API outage.

See #286.

Signed-off-by: William Woodruff <william@trailofbits.com>