### PR TITLE
cache: respect pip's `PIP_NO_CACHE_DIR`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All versions prior to 0.0.9 are untracked.
   about OSV's schema guarantees was fixed
   ([#284](https://github.com/trailofbits/pip-audit/pull/284))
 
+* Caching: `pip-audit` now respects `pip`'s `PIP_NO_CACHE_DIR`
+  and will not attempt to use the `pip` cache if present
+  ([#290](https://github.com/trailofbits/pip-audit/pull/290))
+
 ## [2.3.1] - 2022-05-24
 
 ### Fixed

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -32,6 +32,13 @@ def test_get_cache_dir_do_not_use_pip():
     assert cache_dir == Path.home() / ".pip-audit-cache"
 
 
+def test_get_cache_dir_pip_disabled_in_environment(monkeypatch):
+    monkeypatch.setenv("PIP_NO_CACHE_DIR", "1")
+
+    # Even with use_pip=True, we avoid pip's cache if the environment tells us to.
+    assert _get_cache_dir(None, use_pip=True) == Path.home() / ".pip-audit-cache"
+
+
 def test_get_cache_dir_old_pip(monkeypatch):
     # Check the case where we have an old `pip`
     monkeypatch.setattr(cache, "_PIP_VERSION", Version("1.0.0"))


### PR DESCRIPTION
Closes #289.

Signed-off-by: William Woodruff <william@trailofbits.com>