### PR TITLE
pyproject: add missing toml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pip-api>=0.0.28",
     "resolvelib>=0.8.0",
     "rich>=12.4",
+    "toml>=0.10",
 ]
 requires-python = ">=3.7"
 
@@ -43,6 +44,7 @@ dev = [
     "pytest-cov",
     "types-html5lib",
     "types-requests",
+    "types-toml",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 ]
 dependencies = [
     "CacheControl[filecache]>=0.12.10",
-    "cyclonedx-python-lib>=1.0.0,<3.0.0",
+    # TODO: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
+    "cyclonedx-python-lib>=2.0.0,<2.5.0",
     "html5lib>=1.1",
     "packaging>=21.0.0",
     "pip-api>=0.0.28",


### PR DESCRIPTION
This fixes the lint in the CI and adds `toml` as a dependency.

We should do a release after this, since it's likely that `pyproject.toml` support was broken prior to this (outside of the development environment.)

Signed-off-by: William Woodruff <william@trailofbits.com>