### PR TITLE
pyproject: relax cyclonedx version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,9 @@ classifiers = [
 ]
 dependencies = [
     "CacheControl[filecache]>=0.12.10",
-    # TODO: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
-    "cyclonedx-python-lib>=2.0.0,<2.5.0",
+    # NOTE(ww): Release 2.5.0 is broken, subsequent 2.5.x releases fix it.
+    # See: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
+    "cyclonedx-python-lib>=2.0.0,!=2.5.0",
     "html5lib>=1.1",
     "packaging>=21.0.0",
     "pip-api>=0.0.28",


### PR DESCRIPTION
Follow-up to #292, now that CycloneDX has done a `2.5.1` release.

Signed-off-by: William Woodruff <william@trailofbits.com>