### PR TITLE
requirement, test: Correct `--fix` for subdependencies in requirements files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All versions prior to 0.0.9 are untracked.
   `pyproject.toml` dependency source
   ([#300](https://github.com/trailofbits/pip-audit/pull/300))
 
+* Vulnerability fixing: the `--fix` flag now works for vulnerabilities found in
+  requirement subdependencies. A new line is now added to the requirement file
+  to explicitly pin the offending subdependency
+  ([#297](https://github.com/trailofbits/pip-audit/pull/297))
+
 ## [2.3.2] - 2022-05-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Vulnerability fixing: the `--fix` flag now works for vulnerabilities found in
+  requirement subdependencies. A new line is now added to the requirement file
+  to explicitly pin the offending subdependency
+  ([#297](https://github.com/trailofbits/pip-audit/pull/297))
+
 ## [2.3.3]
 
 ### Changed
@@ -23,11 +30,6 @@ All versions prior to 0.0.9 are untracked.
   dependency resolver behavior now work correctly when auditing a
   `pyproject.toml` dependency source
   ([#300](https://github.com/trailofbits/pip-audit/pull/300))
-
-* Vulnerability fixing: the `--fix` flag now works for vulnerabilities found in
-  requirement subdependencies. A new line is now added to the requirement file
-  to explicitly pin the offending subdependency
-  ([#297](https://github.com/trailofbits/pip-audit/pull/297))
 
 ## [2.3.2] - 2022-05-14
 

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -168,7 +168,9 @@ class RequirementSource(DependencySource):
                             "added fixed subdependency explicitly to requirements file "
                             f"{filename}: {fix_version.dep.canonical_name}"
                         )
-                        origin_reqs_formatted = ",".join([str(req) for req in origin_reqs])
+                        origin_reqs_formatted = ",".join(
+                            [str(req) for req in sorted(list(origin_reqs), key=lambda x: x.name)]
+                        )
                         print(
                             f"# pip-audit: subdependency fixed via {origin_reqs_formatted}",
                             file=f,

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -153,6 +153,10 @@ class RequirementSource(DependencySource):
             # The vulnerable dependency may not be explicitly listed in the requirements file if it
             # is a subdependency of a requirement. In this case, we should explicitly add the fixed
             # dependency into the requirements file.
+            #
+            # To know whether this is the case, we'll need to resolve dependencies if we haven't
+            # already in order to figure out whether this subdependency belongs to this file or
+            # another.
             try:
                 if not fixed and fix_version.dep in self._collect_cached_deps(
                     filename, list(reqs.values())

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -172,7 +172,7 @@ class RequirementSource(DependencySource):
                             [str(req) for req in sorted(list(origin_reqs), key=lambda x: x.name)]
                         )
                         print(
-                            f"# pip-audit: subdependency fixed via {origin_reqs_formatted}",
+                            f"    # pip-audit: subdependency fixed via {origin_reqs_formatted}",
                             file=f,
                         )
                         print(f"{fix_version.dep.canonical_name}=={fix_version.version}", file=f)

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -148,7 +148,7 @@ class RequirementSource(DependencySource):
                     req.specifier = SpecifierSet(f"=={fix_version.version}")
                     fixed = True
                 assert req.marker is None or req.marker.evaluate()
-                f.write(str(req) + os.linesep)
+                print(str(req), file=f)
 
             # The vulnerable dependency may not be explicitly listed in the requirements file if it
             # is a subdependency of a requirement. In this case, we should explicitly add the fixed
@@ -165,8 +165,8 @@ class RequirementSource(DependencySource):
                         f"added fixed subdependency explicitly to requirements file {filename}: "
                         f"{fix_version.dep.canonical_name}"
                     )
-                    f.write("# added by pip-audit to fix subdependency" + os.linesep)
-                    f.write(f"{fix_version.dep.canonical_name}=={fix_version.version}" + os.linesep)
+                    print("# added by pip-audit to fix subdependency", file=f)
+                    print(f"{fix_version.dep.canonical_name}=={fix_version.version}", file=f)
             except DependencyResolverError as dre:
                 raise RequirementFixError from dre
 

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -101,9 +101,11 @@ class VirtualEnv(venv.EnvBuilder):
             *self._install_args,
         ]
         try:
-            run(package_install_cmd, state=self._state)
+            package_install_stdout = run(package_install_cmd, state=self._state)
         except CalledProcessError as cpe:
-            raise VirtualEnvError(f"Failed to install packages: {package_install_cmd}") from cpe
+            raise VirtualEnvError(
+                f"Failed to install packages: {package_install_cmd}\n{package_install_stdout}"
+            ) from cpe
 
         self._state.update_state("Processing package list from isolated environment")
 

--- a/pip_audit/_virtual_env.py
+++ b/pip_audit/_virtual_env.py
@@ -101,11 +101,9 @@ class VirtualEnv(venv.EnvBuilder):
             *self._install_args,
         ]
         try:
-            package_install_stdout = run(package_install_cmd, state=self._state)
+            run(package_install_cmd, state=self._state)
         except CalledProcessError as cpe:
-            raise VirtualEnvError(
-                f"Failed to install packages: {package_install_cmd}\n{package_install_stdout}"
-            ) from cpe
+            raise VirtualEnvError(f"Failed to install packages: {package_install_cmd}") from cpe
 
         self._state.update_state("Processing package list from isolated environment")
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -431,7 +431,7 @@ def test_requirement_source_fix_explicit_subdep(monkeypatch, req_file):
     # associated comment.
     _check_fixes(
         ["flask==2.0.1"],
-        ["flask==2.0.1\n# added by pip-audit to fix subdependency\njinja2==4.0.0"],
+        ["flask==2.0.1\n# pip-audit: subdependency fixed via flask==2.0.1\njinja2==4.0.0"],
         [req_file()],
         [
             ResolvedFixVersion(

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -141,8 +141,8 @@ def test_requirement_source_fix(req_file):
 
 def test_requirement_source_fix_multiple_files(req_file):
     _check_fixes(
-        ["flask==0.5", "requests==1.0\nflask==0.5"],
-        ["flask==1.0", "requests==1.0\nflask==1.0"],
+        ["flask==0.5", "requests==2.0\nflask==0.5"],
+        ["flask==1.0", "requests==2.0\nflask==1.0"],
         [req_file(), req_file()],
         [
             ResolvedFixVersion(
@@ -154,8 +154,8 @@ def test_requirement_source_fix_multiple_files(req_file):
 
 def test_requirement_source_fix_specifier_match(req_file):
     _check_fixes(
-        ["flask<1.0", "requests==1.0\nflask<=0.6"],
-        ["flask==1.0", "requests==1.0\nflask==1.0"],
+        ["flask<1.0", "requests==2.0\nflask<=0.6"],
+        ["flask==1.0", "requests==2.0\nflask==1.0"],
         [req_file(), req_file()],
         [
             ResolvedFixVersion(
@@ -170,8 +170,8 @@ def test_requirement_source_fix_specifier_no_match(req_file):
     # version. If the specifier matches both, we don't apply the fix since installing from the given
     # requirements file would already install the fixed version.
     _check_fixes(
-        ["flask>=0.5", "requests==1.0\nflask<2.0"],
-        ["flask>=0.5", "requests==1.0\nflask<2.0"],
+        ["flask>=0.5", "requests==2.0\nflask<2.0"],
+        ["flask>=0.5", "requests==2.0\nflask<2.0"],
         [req_file(), req_file()],
         [
             ResolvedFixVersion(
@@ -187,11 +187,11 @@ def test_requirement_source_fix_marker(req_file):
     _check_fixes(
         [
             'flask<1.0; python_version > "2.7"',
-            'requests==1.0\nflask<=0.6; python_version <= "2.7"',
+            'requests==2.0\nflask<=0.6; python_version <= "2.7"',
         ],
         [
             'flask==1.0; python_version > "2.7"',
-            "requests==1.0",
+            "requests==2.0",
         ],
         [req_file(), req_file()],
         [
@@ -207,9 +207,9 @@ def test_requirement_source_fix_comments(req_file):
     _check_fixes(
         [
             "# comment here\nflask==0.5",
-            "requests==1.0\n# another comment\nflask==0.5",
+            "requests==2.0\n# another comment\nflask==0.5",
         ],
-        ["flask==1.0", "requests==1.0\nflask==1.0"],
+        ["flask==1.0", "requests==2.0\nflask==1.0"],
         [req_file(), req_file()],
         [
             ResolvedFixVersion(
@@ -225,7 +225,7 @@ def test_requirement_source_fix_parse_failure(monkeypatch, req_file):
 
     # If `pip-api` encounters multiple of the same package in the requirements file, it will throw a
     # parsing error
-    input_reqs = ["flask==0.5", "flask==0.5\nrequests==1.0\nflask==0.3"]
+    input_reqs = ["flask==0.5", "flask==0.5\nrequests==2.0\nflask==0.3"]
     req_paths = [req_file(), req_file()]
 
     # Populate the requirements files
@@ -255,7 +255,7 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
 
     # If `pip-api` encounters multiple of the same package in the requirements file, it will throw a
     # parsing error
-    input_reqs = ["flask==0.5", "flask==0.5\nrequests==1.0\nflask==0.3"]
+    input_reqs = ["flask==0.5", "flask==0.5\nrequests==2.0\nflask==0.3"]
     req_paths = [req_file(), req_file()]
 
     # Populate the requirements files
@@ -282,7 +282,7 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
     # We couldn't move the original requirements files back so we should expect a partially applied
     # fix. The first requirements file contains the fix, while the second one doesn't since we were
     # in the process of writing it out and didn't flush.
-    expected_reqs = ["flask==1.0", "flask==0.5\nrequests==1.0\nflask==0.3"]
+    expected_reqs = ["flask==1.0", "flask==0.5\nrequests==2.0\nflask==0.3"]
     for (expected_req, req_path) in zip(expected_reqs, req_paths):
         with open(req_path, "r") as f:
             assert expected_req == f.read().strip()
@@ -328,7 +328,7 @@ def test_requirement_source_require_hashes_inferred(monkeypatch):
     monkeypatch.setattr(
         _parse_requirements,
         "_read_file",
-        lambda _: ["flask==2.0.1 --hash=sha256:flask-hash\nrequests==1.0"],
+        lambda _: ["flask==2.0.1 --hash=sha256:flask-hash\nrequests==2.0"],
     )
 
     # If at least one requirement is hashed, this infers `require-hashes`

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -431,7 +431,7 @@ def test_requirement_source_fix_explicit_subdep(monkeypatch, req_file):
     # associated comment.
     _check_fixes(
         ["flask==2.0.1"],
-        ["flask==2.0.1\n# pip-audit: subdependency fixed via flask==2.0.1\njinja2==4.0.0"],
+        ["flask==2.0.1\n    # pip-audit: subdependency fixed via flask==2.0.1\njinja2==4.0.0"],
         [req_file()],
         [
             ResolvedFixVersion(
@@ -462,7 +462,7 @@ def test_requirement_source_fix_explicit_subdep_multiple_reqs(monkeypatch, req_f
         ["flask==2.0.1\ndjango-jinja==1.0"],
         [
             "flask==2.0.1\ndjango-jinja==1.0\n"
-            "# pip-audit: subdependency fixed via django-jinja==1.0,flask==2.0.1\n"
+            "    # pip-audit: subdependency fixed via django-jinja==1.0,flask==2.0.1\n"
             "jinja2==4.0.0"
         ],
         [req_file()],


### PR DESCRIPTION
Closes #291

- [x] Figure out test failure on 3.10
- [x] CHANGELOG