### PR TITLE
Refactor the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
 
 name: release
 
@@ -9,26 +9,12 @@ jobs:
   pypi:
     name: upload release to PyPI
     runs-on: ubuntu-latest
-    permissions:
-      # NOTE: Needed to create GitHub releases.
-      contents: write
     steps:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v4
       with:
         python-version: ">= 3.7"
-
-    - name: create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: ${{ contains(github.ref, 'pre') || contains(github.ref, 'rc') }}
 
     - name: deps
       run: python -m pip install -U setuptools build wheel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,27 +96,50 @@ here! They're documented for completeness and for onboarding future maintainers.
 Releases of `pip-audit` are managed with [`bump`](https://github.com/di/bump)
 and GitHub Actions.
 
-```bash
-# default release (patch bump)
-make release
+The following manual steps are required:
 
-# override the default
-# vX.Y.Z -> vX.Y.Z-rc.0
-make release BUMP_ARGS="--pre rc.0"
+1. Create a new development branch for the release. For example:
 
-# vX.Y.Z -> vN.0.0
-make release BUMP_ARGS="--major"
-```
+    ```console
+    $ git checkout -b prepare-1.0.0
+    ```
 
-`make release` will fail if there are any untracked changes in the source tree.
+1. Update `pip-audit`'s `__version__` attribute. It can be found under `pip_audit/__init__.py`.
 
-If `make release` succeeds, you'll see an output like this:
+    **Note**: You can do this automatically with `bump`:
 
-```
-RUN ME MANUALLY: git push origin main && git push origin vX.Y.Z
-```
+    ```console
+    # See bump --help for all options
+    $ bump --major
+    ```
 
-Run that last command sequence to complete the release.
+1. Commit your changes to the branch and create a new Pull Request.
+
+1. Tag another maintainer for review. Once approved, you may merge your PR.
+
+1. Create a new tag corresponding to the merged version change. For example:
+
+    ```console
+    # IMPORTANT: don't forget the `v` prefix!
+    $ git tag v1.0.0
+    ```
+
+1. Push the new tag:
+
+    ```console
+    $ git push origin v1.0.0
+    ```
+
+1. Use the [releases page](https://github.com/trailofbits/pip-audit/releases) to
+   create a new release, marking it as a "pre-release" if appropriate.
+
+1. Copy the relevant
+  [CHANGELOG](https://github.com/trailofbits/pip-audit/blob/main/CHANGELOG.md)
+  entries into the release notes.
+
+1. Save and publish the release. The CI will take care of all other tasks.
+
+
 
 ## Development practices
 

--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,6 @@ package: env/pyvenv.cfg
 	. env/bin/activate && \
 		python3 -m build
 
-.PHONY: release
-release: env/pyvenv.cfg
-	@. env/bin/activate && \
-		NEXT_VERSION=$$(bump $(BUMP_ARGS)) && \
-		git add $(PY_MODULE)/__init__.py && git diff --quiet --exit-code && \
-		git commit -m "version: v$${NEXT_VERSION}" && \
-		git tag v$${NEXT_VERSION} && \
-		echo "RUN ME MANUALLY: git push origin main && git push origin v$${NEXT_VERSION}"
-
-
 .PHONY: edit
 edit:
 	$(EDITOR) $(ALL_PY_SRCS)


### PR DESCRIPTION
This makes the release workflow slightly more manual, and aligns it with the workflow we use on `sigstore-python`.

Closes #302.