### PR TITLE
pip_audit: 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+## [2.4.0]
+
 ### Added
 
 * Output formats: `pip-audit` now supports a Markdown format
@@ -285,6 +287,7 @@ All versions prior to 0.0.9 are untracked.
 
 <!-- Release URLs -->
 [Unreleased]: https://github.com/trailofbits/pip-audit/compare/v2.0.0...HEAD
+[2.4.0]: https://github.com/trailofbits/pip-audit/compare/v2.3.4...v2.4.0
 [2.3.4]: https://github.com/trailofbits/pip-audit/compare/v2.3.3...v2.3.4
 [2.3.3]: https://github.com/trailofbits/pip-audit/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/trailofbits/pip-audit/compare/v2.3.1...v2.3.2

--- a/pip_audit/__init__.py
+++ b/pip_audit/__init__.py
@@ -2,4 +2,4 @@
 The `pip_audit` APIs.
 """
 
-__version__ = "2.3.4"
+__version__ = "2.4.0"


### PR DESCRIPTION
To get the `--format=markdown` changes out the door.

Signed-off-by: William Woodruff <william@trailofbits.com>