### PR TITLE
workflows: Sign releases with `sigstore-python`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
+permissions:
+  id-token: write
+
 jobs:
   test:
     strategy:
@@ -57,3 +60,18 @@ jobs:
             <( \
               python -m pip_audit --help \
             )
+  sign-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ">= 3.7"
+      - name: deps
+        run: python -m pip install -U setuptools build wheel
+      - name: build
+        run: python -m build
+      - name: sign
+        uses: trailofbits/gh-action-sigstore-python@v0.0.2
+        with:
+          inputs: ./dist/*.tar.gz ./dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
-permissions:
-  id-token: write
-
 jobs:
   test:
     strategy:
@@ -60,18 +57,3 @@ jobs:
             <( \
               python -m pip_audit --help \
             )
-  sign-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ">= 3.7"
-      - name: deps
-        run: python -m pip install -U setuptools build wheel
-      - name: build
-        run: python -m build
-      - name: sign
-        uses: trailofbits/gh-action-sigstore-python@v0.0.2
-        with:
-          inputs: ./dist/*.tar.gz ./dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,10 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: sign
+      uses: trailofbits/gh-action-sigstore-python@v0.0.1
+      with:
+        inputs: >
+          "pip_audit-${{ github.event.release.tag_name }}.tar.gz
+          "pip_audit-${{ github.event.release.tag_name }}-py3-none-any.whl"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 
 name: release
 
+permissions:
+  id-token: write
+
 jobs:
   pypi:
     name: upload release to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
     - name: sign
-      uses: trailofbits/gh-action-sigstore-python@v0.0.1
+      uses: trailofbits/gh-action-sigstore-python@v0.0.2
       with:
-        inputs: >
-          "pip_audit-${{ github.event.release.tag_name }}.tar.gz
-          "pip_audit-${{ github.event.release.tag_name }}-py3-none-any.whl"
+        inputs: ./dist/*.tar.gz ./dist/*.whl


### PR DESCRIPTION
Since we've recently created a GitHub Action for `sigstore-python`, I figure we can use `pip-audit` as a testbed for it.