### PR TITLE
requirement: Parse requirements using `pip-requirements-parser` instead of `pip-api`

### DIFF
--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -79,7 +79,7 @@ class RequirementSource(DependencySource):
         collected: Set[Dependency] = set()
         for filename in self._filenames:
             try:
-                rf = RequirementsFile.from_file(filename.name)
+                rf = RequirementsFile.from_file(filename)
                 if rf.invalid_lines:
                     raise RequirementSourceError(
                         f"requirement file {filename} contains invalid lines: "

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -82,7 +82,8 @@ class RequirementSource(DependencySource):
                 rf = RequirementsFile.from_file(filename.name)
                 if rf.invalid_lines:
                     raise RequirementSourceError(
-                        f"Parsed invalid lines, file={filename}, lines={rf.invalid_lines}"
+                        f"requirement file {filename} contains invalid lines: "
+                        f"{str(rf.invalid_lines)}"
                     )
 
                 reqs: List[InstallRequirement] = []
@@ -91,7 +92,9 @@ class RequirementSource(DependencySource):
                     if req.marker is None or req.marker.evaluate():
                         # This means we have a duplicate requirement for the same package
                         if req.name in req_names:
-                            raise RequirementSourceError(f"Found duplicate package: {req.name}")
+                            raise RequirementSourceError(
+                                f"package {req.name} has duplicate requirements: {str(req)}"
+                            )
                         req_names.add(req.name)
                         reqs.append(req)
 
@@ -146,10 +149,14 @@ class RequirementSource(DependencySource):
                 req.marker is None or req.marker.evaluate()
             ):
                 if req.name in req_names:
-                    raise RequirementFixError("Duplicate req")
+                    raise RequirementFixError(
+                        f"package {req.name} has duplicate requirements: {str(req)}"
+                    )
                 req_names.add(req.name)
             elif isinstance(req, InvalidRequirement):
-                raise RequirementFixError("Invalid req")
+                raise RequirementFixError(
+                    f"requirement file {filename} has invalid requirement: {str(req)}"
+                )
 
         # Now write out the new requirements file
         with filename.open("w") as f:

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -138,6 +138,9 @@ class RequirementSource(DependencySource):
     def _fix_file(self, filename: Path, fix_version: ResolvedFixVersion) -> None:
         # Reparse the requirements file. We want to rewrite each line to the new requirements file
         # and only modify the lines that we're fixing.
+        #
+        # This time we're using the `RequirementsFile.parse` API instead of `Requirements.from_file`
+        # since we want to access each line sequentially in order to rewrite the file.
         reqs = list(RequirementsFile.parse(filename=str(filename)))
 
         # Check ahead of time for anything invalid in the requirements file since we don't want to

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -11,10 +11,10 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import IO, Dict, Iterator, List, Set, Tuple, cast
 
-from packaging.requirements import InvalidRequirement, Requirement
+from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
-from pip_requirements_parser import InstallRequirement, RequirementsFile
+from pip_requirements_parser import InstallRequirement, InvalidRequirementLine, RequirementsFile
 
 from pip_audit._dependency_source import (
     DependencyFixError,
@@ -153,7 +153,7 @@ class RequirementSource(DependencySource):
                         f"package {req.name} has duplicate requirements: {str(req)}"
                     )
                 req_names.add(req.name)
-            elif isinstance(req, InvalidRequirement):
+            elif isinstance(req, InvalidRequirementLine):
                 raise RequirementFixError(
                     f"requirement file {filename} has invalid requirement: {str(req)}"
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "html5lib>=1.1",
     "packaging>=21.0.0",
     "pip-api>=0.0.28",
+    "pip-requirements-parser>=31.2.0",
     "resolvelib>=0.8.0",
     "rich>=12.4",
     "toml>=0.10",

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -32,12 +32,12 @@ def test_requirement_source(monkeypatch):
 
 @pytest.mark.online
 def test_requirement_source_multiple_files(monkeypatch):
-    file1 = "requirements1.txt"
-    file2 = "requirements2.txt"
-    file3 = "requirements3.txt"
+    file1 = Path("requirements1.txt")
+    file2 = Path("requirements2.txt")
+    file3 = Path("requirements3.txt")
 
     source = requirement.RequirementSource(
-        [Path(file1), Path(file2), Path(file3)],
+        [file1, file2, file3],
         ResolveLibResolver(),
     )
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -7,7 +7,6 @@ import pretend  # type: ignore
 import pytest
 from packaging.requirements import Requirement
 from packaging.version import Version
-from pip_api import _parse_requirements
 
 from pip_audit._dependency_source import (
     DependencyFixError,
@@ -345,7 +344,8 @@ def test_requirement_source_require_hashes_unpinned(monkeypatch):
     monkeypatch.setattr(
         pip_requirements_parser,
         "get_file_content",
-        lambda _: "flask==2.0.1 --hash=sha256:flask-hash\nrequests>=1.0 --hash=sha256:requests-hash",
+        lambda _: "flask==2.0.1 --hash=sha256:flask-hash\nrequests>=1.0 "
+        "--hash=sha256:requests-hash",
     )
 
     # When hashed dependencies are provided, all dependencies must be explicitly pinned to an exact
@@ -517,7 +517,8 @@ def test_requirement_source_fix_explicit_subdep_comment_retension(req_file):
     # When we "fix" dependencies, we parse the requirements file and write it back out with the
     # relevant line amended or added. When we used `pip-api` for requirements parsing, our fix logic
     # had the unfortunate side effect of stripping comments from the file. Importantly, when we
-    # applied subdependency fixes, the automated comments used to be removed by any subsequent fixes.
+    # applied subdependency fixes, the automated comments used to be removed by any subsequent
+    # fixes.
     #
     # Since we've switching `pip-requirements-parser`, we should no longer have this issue.
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -262,6 +262,7 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
         with open(req_path, "w") as f:
             f.write(input_req)
 
+    # Simulate an error being raised during file recovery
     def mock_replace(*_args, **_kwargs):
         raise OSError
 

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -212,7 +212,6 @@ def test_requirement_source_fix_preserve_marker(req_file):
 
 
 def test_requirement_source_fix_comments(req_file):
-    # `pip-api` automatically filters out comments
     _check_fixes(
         [
             "# comment here\nflask==0.5",
@@ -232,8 +231,8 @@ def test_requirement_source_fix_parse_failure(monkeypatch, req_file):
     logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(requirement, "logger", logger)
 
-    # If `pip-api` encounters multiple of the same package in the requirements file, it will throw a
-    # parsing error
+    # If we encounter multiple of the same package in the requirements file, we will throw a parsing
+    # error
     input_reqs = ["flask==0.5", "flask==0.5\nrequests==2.0\nflask==0.3"]
     req_paths = [req_file(), req_file()]
 
@@ -262,8 +261,8 @@ def test_requirement_source_fix_rollback_failure(monkeypatch, req_file):
     logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(requirement, "logger", logger)
 
-    # If `pip-api` encounters multiple of the same package in the requirements file, it will throw a
-    # parsing error
+    # If we encounter multiple of the same package in the requirements file, we will throw a parsing
+    # error
     input_reqs = ["flask==0.5", "flask==0.5\nrequests==2.0\nflask==0.3"]
     req_paths = [req_file(), req_file()]
 


### PR DESCRIPTION
Extended discussion can be found at https://github.com/di/pip-api/issues/120. The `pip-requirements-parser` package is more complete and `pip-api` is not intending to support this API going forward (more detail in https://github.com/di/pip-api/issues/121) so we've decided to port `pip-audit` to `pip-requirements-parser` for the time being.

CC: @pombredanne