### PR TITLE
OSV, PyPI: Do not use "details" field for vuln summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* CLI: the `--format=markdown` and `--format=columns` output formats are no
+  longer broken by long vulnerability descriptions from the OSV and PyPI
+  vulnerability sources ([#323](https://github.com/trailofbits/pip-audit/pull/323))
+
 ## [2.4.1]
 
 ### Fixed

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -90,9 +90,19 @@ class OsvService(VulnerabilityService):
 
             id = vuln["id"]
 
+            # The summary is intended to be shorter, so we prefer it over
+            # details, if present. However, neither is required.
             description = vuln.get("summary")
             if description is None:
+                description = vuln.get("details")
+            if description is None:
                 description = "N/A"
+
+            # The "summary" field should be a single line, but "details" might
+            # be multiple (Markdown-formatted) lines. So, we normalize our
+            # description into a single line (and potentially break the Markdown
+            # formatting in the process).
+            description = description.replace("\n", " ")
 
             aliases = set(vuln.get("aliases", []))
 

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -90,11 +90,7 @@ class OsvService(VulnerabilityService):
 
             id = vuln["id"]
 
-            # The summary is intended to be shorter, so we prefer it over
-            # details, if present. However, neither is required.
             description = vuln.get("summary")
-            if description is None:
-                description = vuln.get("details")
             if description is None:
                 description = "N/A"
 

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -117,8 +117,12 @@ class PyPIService(VulnerabilityService):
             # The ranges aren't guaranteed to come in chronological order
             fix_versions.sort()
 
+            description = v.get("summary")
+            if description is None:
+                description = "N/A"
+
             results.append(
-                VulnerabilityResult(v["id"], v["details"], fix_versions, set(v["aliases"]))
+                VulnerabilityResult(v["id"], description, fix_versions, set(v["aliases"]))
             )
 
         return spec, results

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -119,7 +119,16 @@ class PyPIService(VulnerabilityService):
 
             description = v.get("summary")
             if description is None:
+                description = v.get("details")
+
+            if description is None:
                 description = "N/A"
+
+            # The "summary" field should be a single line, but "details" might
+            # be multiple (Markdown-formatted) lines. So, we normalize our
+            # description into a single line (and potentially break the Markdown
+            # formatting in the process).
+            description = description.replace("\n", " ")
 
             results.append(
                 VulnerabilityResult(v["id"], description, fix_versions, set(v["aliases"]))

--- a/test/service/test_osv.py
+++ b/test/service/test_osv.py
@@ -168,18 +168,22 @@ def test_osv_unsupported_schema_version(monkeypatch, version):
 
 
 @pytest.mark.parametrize(
-    ["summary", "description"],
+    ["summary", "details", "description"],
     [
-        ("fakesummary", "fakesummary"),
-        (None, "N/A"),
+        ("fakesummary", "fakedetails", "fakesummary"),
+        ("fakesummary\nanother line", "fakedetails", "fakesummary another line"),
+        (None, "fakedetails", "fakedetails"),
+        (None, "fakedetails\nanother line", "fakedetails another line"),
+        (None, None, "N/A"),
     ],
 )
-def test_osv_vuln_description_fallbacks(monkeypatch, summary, description):
+def test_osv_vuln_description_fallbacks(monkeypatch, summary, details, description):
     payload = {
         "vulns": [
             {
                 "id": "fakeid",
                 "summary": summary,
+                "details": details,
                 "affected": [
                     {
                         "package": {"name": "foo", "ecosystem": "PyPI"},

--- a/test/service/test_osv.py
+++ b/test/service/test_osv.py
@@ -168,20 +168,18 @@ def test_osv_unsupported_schema_version(monkeypatch, version):
 
 
 @pytest.mark.parametrize(
-    ["summary", "details", "description"],
+    ["summary", "description"],
     [
-        ("fakesummary", "fakedetails", "fakesummary"),
-        (None, "fakedetails", "fakedetails"),
-        (None, None, "N/A"),
+        ("fakesummary", "fakesummary"),
+        (None, "N/A"),
     ],
 )
-def test_osv_vuln_description_fallbacks(monkeypatch, summary, details, description):
+def test_osv_vuln_description_fallbacks(monkeypatch, summary, description):
     payload = {
         "vulns": [
             {
                 "id": "fakeid",
                 "summary": summary,
-                "details": details,
                 "affected": [
                     {
                         "package": {"name": "foo", "ecosystem": "PyPI"},

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -172,6 +172,57 @@ def test_pypi_mocked_response(monkeypatch, cache_dir):
     )
 
 
+@pytest.mark.parametrize(
+    ["summary", "details", "description"],
+    [
+        ("fakesummary", "fakedetails", "fakesummary"),
+        ("fakesummary\nanother line", "fakedetails", "fakesummary another line"),
+        (None, "fakedetails", "fakedetails"),
+        (None, "fakedetails\nanother line", "fakedetails another line"),
+        (None, None, "N/A"),
+    ],
+)
+def test_pypi_vuln_description_fallbacks(monkeypatch, cache_dir, summary, details, description):
+    def get_mock_response():
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "vulnerabilities": [
+                        {
+                            "aliases": ["foo", "bar"],
+                            "id": "VULN-0",
+                            "summary": summary,
+                            "details": details,
+                            "fixed_in": ["1.1", "1.4"],
+                        }
+                    ]
+                }
+
+        return MockResponse()
+
+    monkeypatch.setattr(
+        service.pypi, "caching_session", lambda _: get_mock_session(get_mock_response)
+    )
+
+    pypi = service.PyPIService(cache_dir)
+    dep = service.ResolvedDependency("foo", Version("1.0"))
+    results: Dict[service.Dependency, List[service.VulnerabilityResult]] = dict(
+        pypi.query_all(iter([dep]))
+    )
+    assert len(results) == 1
+    assert dep in results
+    assert len(results[dep]) == 1
+    assert results[dep][0] == service.VulnerabilityResult(
+        id="VULN-0",
+        description=description,
+        fix_versions=[Version("1.1"), Version("1.4")],
+        aliases={"foo", "bar"},
+    )
+
+
 def test_pypi_no_vuln_key(monkeypatch, cache_dir):
     def get_mock_response():
         class MockResponse:
@@ -209,7 +260,7 @@ def test_pypi_invalid_version(monkeypatch, cache_dir):
                         {
                             "aliases": ["foo", "bar"],
                             "id": "VULN-0",
-                            "details": "The first vulnerability",
+                            "summary": "The first vulnerability",
                             "fixed_in": ["invalid_version"],
                         }
                     ]
@@ -278,7 +329,7 @@ def test_pypi_hashed_dep_no_release_data(cache_dir, monkeypatch):
                     "vulnerabilities": [
                         {
                             "id": "VULN-0",
-                            "details": "The first vulnerability",
+                            "summary": "The first vulnerability",
                             "fixed_in": ["1.1"],
                         }
                     ],

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -144,7 +144,7 @@ def test_pypi_mocked_response(monkeypatch, cache_dir):
                         {
                             "aliases": ["foo", "bar"],
                             "id": "VULN-0",
-                            "details": "The first vulnerability",
+                            "summary": "The first vulnerability",
                             "fixed_in": ["1.1", "1.4"],
                         }
                     ]


### PR DESCRIPTION
The "details" field is frequently multiline and OSV allows it to be Markdown formatted, which causes problems for the surrounding columnar and Markdown formats. The correct field in our context is the "summary" field, which is specified as a short plaintext string.

Closes #314.