### PR TITLE
Skip editable requirements

### DIFF
--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -89,6 +89,9 @@ class RequirementSource(DependencySource):
                 reqs: List[InstallRequirement] = []
                 req_names: Set[str] = set()
                 for req in rf.requirements:
+                    if req.is_editable:
+                        # We can't evaluate editable requirements
+                        continue
                     if req.marker is None or req.marker.evaluate():
                         # This means we have a duplicate requirement for the same package
                         if req.name in req_names:

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -577,3 +577,14 @@ def test_requirement_source_fix_invalid_lines(req_file):
                 dep=ResolvedDependency(name="flask", version=Version("0.5")), version=Version("1.0")
             )
         )
+
+
+def test_requirement_source_editable(monkeypatch):
+    source = requirement.RequirementSource([Path("requirements1.txt")], ResolveLibResolver())
+
+    # Return the same requirements for both files
+    monkeypatch.setattr(pip_requirements_parser, "get_file_content", lambda _: "-e foo")
+
+    specs = list(source.collect())
+
+    assert len(specs) == len(set(specs))


### PR DESCRIPTION
Fixes #327. I think the best we can do here is skip the requirement if it's editable.