### PR TITLE
Makefile: Tweak linting target and add new `reformat` target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ make lint
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage
 
+To automatically apply any lint-suggested changes, you can run:
+
+```bash
+make reformat
+```
+
 
 ### Testing
 

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,17 @@ env/pyvenv.cfg: pyproject.toml
 .PHONY: lint
 lint: env/pyvenv.cfg
 	. env/bin/activate && \
-		black $(ALL_PY_SRCS) && \
-		isort $(ALL_PY_SRCS) && \
+		black --check $(ALL_PY_SRCS) && \
+		isort --check $(ALL_PY_SRCS) && \
 		flake8 $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		interrogate -c pyproject.toml .
+
+.PHONY: reformat
+reformat:
+	. env/bin/activate && \
+		black $(ALL_PY_SRCS) && \
+		isort $(ALL_PY_SRCS)
 
 .PHONY: test tests
 test tests: env/pyvenv.cfg


### PR DESCRIPTION
The ideas from #171 are good so I figure we should port them across to `pip-audit`.