### PR TITLE
pyproject: Use recursive extras to optimize the build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: test
-        run: make test
+        run: make test PIP_AUDIT_EXTRA=test
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.7"
       - name: lint
-        run: make lint
+        run: make lint PIP_AUDIT_EXTRA=lint
   check-readme:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ BUMP_ARGS :=
 # Optionally overridden by the user in the `test` target.
 TESTS :=
 
+# Optionally overridden by the user/CI, to limit the installation to a specific
+# subset of development dependencies.
+PIP_AUDIT_EXTRA := dev
+
 # If the user selects a specific test pattern to run, set `pytest` to fail fast
 # and only run tests that match the pattern.
 # Otherwise, run all tests and enable coverage assertions, since we expect
@@ -32,7 +36,7 @@ env/pyvenv.cfg: pyproject.toml
 	# Create our Python 3 virtual environment
 	python3 -m venv env
 	./env/bin/python -m pip install --upgrade pip
-	./env/bin/python -m pip install -e .[dev]
+	./env/bin/python -m pip install -e .[$(PIP_AUDIT_EXTRA)]
 
 .PHONY: lint
 lint: env/pyvenv.cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-tests = [
+test = [
     "coverage[toml]",
     "pretend",
     "pytest",
@@ -61,7 +61,7 @@ lint = [
 dev = [
     "build",
     "bump>=1.3.2",
-    "pip-audit[tests,lint]",
+    "pip-audit[test,lint]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,22 +41,27 @@ dependencies = [
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-dev = [
-    "build",
-    "black>=22.3.0",
-    "bump>=1.3.2",
+tests = [
     "coverage[toml]",
+    "pretend",
+    "pytest",
+    "pytest-cov",
+]
+lint = [
+    "black>=22.3.0",
     "flake8",
     "interrogate",
     "isort",
     "mypy",
     "pdoc3",
-    "pretend",
-    "pytest",
-    "pytest-cov",
     "types-html5lib",
     "types-requests",
     "types-toml",
+]
+dev = [
+    "build",
+    "bump>=1.3.2",
+    "pip-audit[tests,lint]",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This breaks the `dev` extra into two sub-extras, `test` and `lint`, allowing us to install only the subset of development dependencies needed for each. This in turn allows us to optimize our CI by installing only the dependencies required for each CI job.

Also: I'm using this PR to test `gitsign`, which is why the commits are marked as "Unverified". But they're signed via Sigstore + my GitHub identity!