### PR TITLE
workflows/release: bump sigstore action, upload signing artifacts to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
     - name: sign
-      uses: trailofbits/gh-action-sigstore-python@v0.0.4
+      uses: trailofbits/gh-action-sigstore-python@v0.0.7
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
-        upload-signing-artifacts: true
+        release-signing-artifacts: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
 name: release
 
 permissions:
+  # Used to sign the release's artifacts with sigstore-python.
   id-token: write
+
+  # Used to attach signing artifacts to the published release.
+  contents: write
 
 jobs:
   pypi:
@@ -32,6 +36,7 @@ jobs:
         password: ${{ secrets.PYPI_TOKEN }}
 
     - name: sign
-      uses: trailofbits/gh-action-sigstore-python@v0.0.2
+      uses: trailofbits/gh-action-sigstore-python@v0.0.4
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
+        upload-signing-artifacts: true


### PR DESCRIPTION
This will attach the `.crt` and `.sig` files for each distribution file to the GitHub release.

Signed-off-by: William Woodruff <william@trailofbits.com>