### PR TITLE
pyproject: fix classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: 3.7",
-    "Programming Language :: Python :: 3 :: 3.8",
-    "Programming Language :: Python :: 3 :: 3.9",
-    "Programming Language :: Python :: 3 :: 3.10",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Security",
 ]
 dependencies = [


### PR DESCRIPTION
PR #337 introduced new classifiers, some of which cause the build to abort:

```
$ python -m flit build --format wheel
Fetching list of valid trove classifiers                                   I-flit.validate
Unrecognised classifier: 'Programming Language :: Python :: 3 :: 3.10'     E-flit.validate
Unrecognised classifier: 'Programming Language :: Python :: 3 :: 3.7'      E-flit.validate
Unrecognised classifier: 'Programming Language :: Python :: 3 :: 3.8'      E-flit.validate
Unrecognised classifier: 'Programming Language :: Python :: 3 :: 3.9'      E-flit.validate
Config error: Invalid config values (see log)
```

Looking at [PyPI’s list of valid classifiers](https://pypi.org/pypi?%3Aaction=list_classifiers) confirms that minor version classifiers have no intermediate `3` element.

I think the reason that the CI never caught this issue is that because the Makefile seems not to use Flit.

This PR removes the intermediate elements of affected classifiers.

btw:  
Shoutout to @woodruffw and others for your amazing work!
