### PR TITLE
updated cyclonedx dependency

### DIFF
--- a/pip_audit/_format/cyclonedx.py
+++ b/pip_audit/_format/cyclonedx.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 class _PipAuditResultParser(BaseParser):
     def __init__(self, result: dict[service.Dependency, list[service.VulnerabilityResult]]):
         super().__init__()
+        self.vulnerabilities = []
 
         for dep, vulns in result.items():
             # TODO(alex): Is there anything interesting we can do with skipped dependencies in
@@ -34,7 +35,7 @@ class _PipAuditResultParser(BaseParser):
 
             c = Component(name=dep.name, version=str(dep.version))
             for vuln in vulns:
-                c.add_vulnerability(
+                self.vulnerabilities.append(
                     Vulnerability(
                         id=vuln.id,
                         description=vuln.description,
@@ -92,6 +93,7 @@ class CycloneDxFormat(VulnerabilityFormat):
 
         parser = _PipAuditResultParser(result)
         bom = Bom.from_parser(parser)
+        bom.vulnerabilities = parser.vulnerabilities
 
         formatter = output.get_instance(
             bom=bom,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "CacheControl[filecache] >= 0.12.0",
     # NOTE(ww): Release 2.5.0 is broken, subsequent 2.5.x releases fix it.
     # See: https://github.com/CycloneDX/cyclonedx-python-lib/issues/245
-    "cyclonedx-python-lib ~= 2.0, != 2.5.0",
+    "cyclonedx-python-lib ~= 4.0",
     "html5lib>=1.1",
     "packaging>=23.0.0",                     # https://github.com/pypa/pip-audit/issues/464
     "pip-api>=0.0.28",


### PR DESCRIPTION
I've had a quick look at #575 and have seen that it is quite straight  forward. Therefore, I've had a go at it.

To check that the same result is generated I've updated a test to check that the JSON is the same. The only change in the generated JSON was that the vulnerabilities got sorted and in the `dependencies` the value `'dependsOn': [],` is missing.

Since it is not the aim of the test to test the exact output I did not commit it. If you are interested in the test I changed I can submit it as well. https://github.com/pypa/pip-audit/blob/f7a22cf193569aaa6ad2c00874ebf07fda65ddd5/test/format/test_cyclonedx.py#L21

Additionally, I don't think that the `_PipAuditResultParser` is necessary and it could be a function, because the `BaseParser` does not really add functionality. If  you feel the same way I can refactor it. https://github.com/pypa/pip-audit/blob/f7a22cf193569aaa6ad2c00874ebf07fda65ddd5/pip_audit/_format/cyclonedx.py#L24