### PR TITLE
Add hyperlinks for PyPI and OSV

### DIFF
--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -14,7 +14,7 @@ from packaging.version import Version
 import pip_audit._fix as fix
 import pip_audit._service as service
 
-from .interface import VulnerabilityFormat
+from .interface import VulnerabilityFormat, pypi_url, vuln_id_url
 
 _OSC8_RE = re.compile(r"\033]8;;[^\033]*\033\\")
 
@@ -22,16 +22,6 @@ _OSC8_RE = re.compile(r"\033]8;;[^\033]*\033\\")
 def _osc8_link(text: str, url: str) -> str:
     """Wrap text in an OSC 8 terminal hyperlink."""
     return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
-
-
-def _vuln_id_url(vuln_id: str) -> str:
-    """Return the OSV URL for a vulnerability ID."""
-    return f"https://osv.dev/vulnerability/{vuln_id}"
-
-
-def _pypi_url(name: str) -> str:
-    """Return the PyPI URL for a package."""
-    return f"https://pypi.org/project/{name}/"
 
 
 def _visible_len(s: str) -> int:
@@ -159,15 +149,15 @@ class ColumnsFormat(VulnerabilityFormat):
         applied_fix: fix.FixVersion | None,
     ) -> list[Any]:
         vuln_data = [
-            _osc8_link(dep.canonical_name, _pypi_url(dep.canonical_name)),
+            _osc8_link(dep.canonical_name, pypi_url(dep.canonical_name)),
             dep.version,
-            _osc8_link(vuln.id, _vuln_id_url(vuln.id)),
+            _osc8_link(vuln.id, vuln_id_url(vuln.id)),
             self._format_fix_versions(vuln.fix_versions),
         ]
         if applied_fix is not None:
             vuln_data.append(self._format_applied_fix(applied_fix))
         if self.output_aliases:
-            vuln_data.append(", ".join(_osc8_link(a, _vuln_id_url(a)) for a in vuln.aliases))
+            vuln_data.append(", ".join(_osc8_link(a, vuln_id_url(a)) for a in vuln.aliases))
         if self.output_desc:
             vuln_data.append(vuln.description)
         return vuln_data

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -4,6 +4,7 @@ Functionality for formatting vulnerability results as a set of human-readable co
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from itertools import zip_longest
 from typing import Any, cast
@@ -15,6 +16,33 @@ import pip_audit._service as service
 
 from .interface import VulnerabilityFormat
 
+_OSC8_RE = re.compile(r"\033]8;;[^\033]*\033\\")
+
+
+def _osc8_link(text: str, url: str) -> str:
+    """Wrap text in an OSC 8 terminal hyperlink."""
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def _vuln_id_url(vuln_id: str) -> str:
+    """Return the OSV URL for a vulnerability ID."""
+    return f"https://osv.dev/vulnerability/{vuln_id}"
+
+
+def _pypi_url(name: str) -> str:
+    """Return the PyPI URL for a package."""
+    return f"https://pypi.org/project/{name}/"
+
+
+def _visible_len(s: str) -> int:
+    """Return the visible length of a string, ignoring OSC 8 escape sequences."""
+    return len(_OSC8_RE.sub("", s))
+
+
+def _visible_ljust(s: str, width: int) -> str:
+    """Left-justify a string to the given visible width, ignoring OSC 8 escapes."""
+    return s + " " * (width - _visible_len(s))
+
 
 def tabulate(rows: Iterable[Iterable[Any]]) -> tuple[list[str], list[int]]:
     """Return a list of formatted rows and a list of column sizes.
@@ -23,8 +51,8 @@ def tabulate(rows: Iterable[Iterable[Any]]) -> tuple[list[str], list[int]]:
     (['foobar     2000', '3735928559'], [10, 4])
     """
     rows = [tuple(map(str, row)) for row in rows]
-    sizes = [max(map(len, col)) for col in zip_longest(*rows, fillvalue="")]
-    table = [" ".join(map(str.ljust, row, sizes)).rstrip() for row in rows]
+    sizes = [max(map(_visible_len, col)) for col in zip_longest(*rows, fillvalue="")]
+    table = [" ".join(map(_visible_ljust, row, sizes)).rstrip() for row in rows]
     return table, sizes
 
 
@@ -129,15 +157,15 @@ class ColumnsFormat(VulnerabilityFormat):
         applied_fix: fix.FixVersion | None,
     ) -> list[Any]:
         vuln_data = [
-            dep.canonical_name,
+            _osc8_link(dep.canonical_name, _pypi_url(dep.canonical_name)),
             dep.version,
-            vuln.id,
+            _osc8_link(vuln.id, _vuln_id_url(vuln.id)),
             self._format_fix_versions(vuln.fix_versions),
         ]
         if applied_fix is not None:
             vuln_data.append(self._format_applied_fix(applied_fix))
         if self.output_aliases:
-            vuln_data.append(", ".join(vuln.aliases))
+            vuln_data.append(", ".join(_osc8_link(a, _vuln_id_url(a)) for a in vuln.aliases))
         if self.output_desc:
             vuln_data.append(vuln.description)
         return vuln_data

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -143,6 +143,8 @@ class ColumnsFormat(VulnerabilityFormat):
             skip_strings, sizes = tabulate(skip_data)
             skip_strings.insert(1, " ".join("-" * x for x in sizes))
 
+            if columns_string:
+                columns_string += "\n"
             for row in skip_strings:
                 if columns_string:
                     columns_string += "\n"

--- a/pip_audit/_format/columns.py
+++ b/pip_audit/_format/columns.py
@@ -5,6 +5,7 @@ Functionality for formatting vulnerability results as a set of human-readable co
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Iterable
 from itertools import zip_longest
 from typing import Any, cast
@@ -148,16 +149,17 @@ class ColumnsFormat(VulnerabilityFormat):
         vuln: service.VulnerabilityResult,
         applied_fix: fix.FixVersion | None,
     ) -> list[Any]:
+        link = _osc8_link if sys.stdout.isatty() else lambda text, _url: text
         vuln_data = [
-            _osc8_link(dep.canonical_name, pypi_url(dep.canonical_name)),
+            link(dep.canonical_name, pypi_url(dep.canonical_name)),
             dep.version,
-            _osc8_link(vuln.id, vuln_id_url(vuln.id)),
+            link(vuln.id, vuln_id_url(vuln.id)),
             self._format_fix_versions(vuln.fix_versions),
         ]
         if applied_fix is not None:
             vuln_data.append(self._format_applied_fix(applied_fix))
         if self.output_aliases:
-            vuln_data.append(", ".join(_osc8_link(a, vuln_id_url(a)) for a in vuln.aliases))
+            vuln_data.append(", ".join(link(a, vuln_id_url(a)) for a in vuln.aliases))
         if self.output_desc:
             vuln_data.append(vuln.description)
         return vuln_data

--- a/pip_audit/_format/interface.py
+++ b/pip_audit/_format/interface.py
@@ -10,6 +10,16 @@ import pip_audit._fix as fix
 import pip_audit._service as service
 
 
+def vuln_id_url(vuln_id: str) -> str:
+    """Return the OSV URL for a vulnerability ID."""
+    return f"https://osv.dev/vulnerability/{vuln_id}"
+
+
+def pypi_url(name: str) -> str:
+    """Return the PyPI URL for a package."""
+    return f"https://pypi.org/project/{name}/"
+
+
 class VulnerabilityFormat(ABC):
     """
     Represents an abstract string representation for vulnerability results.

--- a/pip_audit/_format/markdown.py
+++ b/pip_audit/_format/markdown.py
@@ -12,7 +12,12 @@ from packaging.version import Version
 import pip_audit._fix as fix
 import pip_audit._service as service
 
-from .interface import VulnerabilityFormat
+from .interface import VulnerabilityFormat, pypi_url, vuln_id_url
+
+
+def _md_link(text: str, url: str) -> str:
+    """Return a Markdown link."""
+    return f"[{text}]({url})"
 
 
 class MarkdownFormat(VulnerabilityFormat):
@@ -104,14 +109,17 @@ class MarkdownFormat(VulnerabilityFormat):
         vuln: service.VulnerabilityResult,
         applied_fix: fix.FixVersion | None,
     ) -> str:
+        name_link = _md_link(dep.canonical_name, pypi_url(dep.canonical_name))
+        id_link = _md_link(vuln.id, vuln_id_url(vuln.id))
         vuln_text = (
-            f"{dep.canonical_name} | {dep.version} | {vuln.id} | "
+            f"{name_link} | {dep.version} | {id_link} | "
             f"{self._format_fix_versions(vuln.fix_versions)}"
         )
         if applied_fix is not None:
             vuln_text += f" | {self._format_applied_fix(applied_fix)}"
         if self.output_aliases:
-            vuln_text += f" | {', '.join(vuln.aliases)}"
+            linked_aliases = ", ".join(_md_link(a, vuln_id_url(a)) for a in vuln.aliases)
+            vuln_text += f" | {linked_aliases}"
         if self.output_desc:
             vuln_text += f" | {vuln.description}"
         return vuln_text

--- a/test/format/test_columns.py
+++ b/test/format/test_columns.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import pip_audit._format as format
@@ -22,39 +24,39 @@ def test_columns_not_manifest(output_desc, output_aliases):
 
 def test_columns(vuln_data):
     columns_format = format.ColumnsFormat(True, True)
-    expected_columns = f"""Name Version ID     Fix Versions Aliases        Description
+    expected_columns = """Name Version ID     Fix Versions Aliases        Description
 ---- ------- ------ ------------ -------------- ------------------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")} The first vulnerability
-{_P("foo")}  1.0     {_V("VULN-1")} 1.0          {_V("CVE-0000-00001")} The second vulnerability
-{_P("bar")}  0.1     {_V("VULN-2")}              {_V("CVE-0000-00002")} The third vulnerability"""
+foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000 The first vulnerability
+foo  1.0     VULN-1 1.0          CVE-0000-00001 The second vulnerability
+bar  0.1     VULN-2              CVE-0000-00002 The third vulnerability"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_no_desc(vuln_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = f"""Name Version ID     Fix Versions Aliases
+    expected_columns = """Name Version ID     Fix Versions Aliases
 ---- ------- ------ ------------ --------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
-{_P("foo")}  1.0     {_V("VULN-1")} 1.0          {_V("CVE-0000-00001")}
-{_P("bar")}  0.1     {_V("VULN-2")}              {_V("CVE-0000-00002")}"""
+foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000
+foo  1.0     VULN-1 1.0          CVE-0000-00001
+bar  0.1     VULN-2              CVE-0000-00002"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_no_desc_no_aliases(vuln_data):
     columns_format = format.ColumnsFormat(False, False)
-    expected_columns = f"""Name Version ID     Fix Versions
+    expected_columns = """Name Version ID     Fix Versions
 ---- ------- ------ ------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4
-{_P("foo")}  1.0     {_V("VULN-1")} 1.0
-{_P("bar")}  0.1     {_V("VULN-2")}"""
+foo  1.0     VULN-0 1.1,1.4
+foo  1.0     VULN-1 1.0
+bar  0.1     VULN-2"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_skipped_dep(vuln_data_skipped_dep):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = f"""Name Version ID     Fix Versions Aliases
+    expected_columns = """Name Version ID     Fix Versions Aliases
 ---- ------- ------ ------------ --------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
+foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000
 
 Name Skip Reason
 ---- -----------
@@ -78,19 +80,30 @@ bar  skip-reason"""
 
 def test_columns_fix(vuln_data, fix_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = f"""Name Version ID     Fix Versions Applied Fix                            Aliases
+    expected_columns = """Name Version ID     Fix Versions Applied Fix                            Aliases
 ---- ------- ------ ------------ -------------------------------------- --------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00000")}
-{_P("foo")}  1.0     {_V("VULN-1")} 1.0          Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00001")}
-{_P("bar")}  0.1     {_V("VULN-2")}              Successfully upgraded bar (0.1 => 0.3) {_V("CVE-0000-00002")}"""
+foo  1.0     VULN-0 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) CVE-0000-00000
+foo  1.0     VULN-1 1.0          Successfully upgraded foo (1.0 => 1.8) CVE-0000-00001
+bar  0.1     VULN-2              Successfully upgraded bar (0.1 => 0.3) CVE-0000-00002"""
     assert columns_format.format(vuln_data, fix_data) == expected_columns
 
 
 def test_columns_skipped_fix(vuln_data, skipped_fix_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = f"""Name Version ID     Fix Versions Applied Fix                            Aliases
+    expected_columns = """Name Version ID     Fix Versions Applied Fix                            Aliases
 ---- ------- ------ ------------ -------------------------------------- --------------
-{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00000")}
-{_P("foo")}  1.0     {_V("VULN-1")} 1.0          Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00001")}
-{_P("bar")}  0.1     {_V("VULN-2")}              Failed to fix bar (0.1): skip-reason   {_V("CVE-0000-00002")}"""
+foo  1.0     VULN-0 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) CVE-0000-00000
+foo  1.0     VULN-1 1.0          Successfully upgraded foo (1.0 => 1.8) CVE-0000-00001
+bar  0.1     VULN-2              Failed to fix bar (0.1): skip-reason   CVE-0000-00002"""
     assert columns_format.format(vuln_data, skipped_fix_data) == expected_columns
+
+
+def test_columns_terminal_links(monkeypatch, vuln_data):
+    monkeypatch.setattr(sys, "stdout", type("FakeTTY", (), {"isatty": lambda self: True})())
+    columns_format = format.ColumnsFormat(False, True)
+    expected_columns = f"""Name Version ID     Fix Versions Aliases
+---- ------- ------ ------------ --------------
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0          {_V("CVE-0000-00001")}
+{_P("bar")}  0.1     {_V("VULN-2")}              {_V("CVE-0000-00002")}"""
+    assert columns_format.format(vuln_data, []) == expected_columns

--- a/test/format/test_columns.py
+++ b/test/format/test_columns.py
@@ -54,6 +54,7 @@ def test_columns_skipped_dep(vuln_data_skipped_dep):
     expected_columns = f"""Name Version ID     Fix Versions Aliases
 ---- ------- ------ ------------ --------------
 {_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
+
 Name Skip Reason
 ---- -----------
 bar  skip-reason"""

--- a/test/format/test_columns.py
+++ b/test/format/test_columns.py
@@ -1,6 +1,16 @@
 import pytest
 
 import pip_audit._format as format
+from pip_audit._format.columns import _osc8_link, _pypi_url, _vuln_id_url
+
+
+# Shortcuts for building expected output with OSC8 links
+def _P(name):
+    return _osc8_link(name, _pypi_url(name))
+
+
+def _V(vid):
+    return _osc8_link(vid, _vuln_id_url(vid))
 
 
 @pytest.mark.parametrize("output_desc, output_aliases", ([True, False], [True, False]))
@@ -11,39 +21,39 @@ def test_columns_not_manifest(output_desc, output_aliases):
 
 def test_columns(vuln_data):
     columns_format = format.ColumnsFormat(True, True)
-    expected_columns = """Name Version ID     Fix Versions Aliases        Description
+    expected_columns = f"""Name Version ID     Fix Versions Aliases        Description
 ---- ------- ------ ------------ -------------- ------------------------
-foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000 The first vulnerability
-foo  1.0     VULN-1 1.0          CVE-0000-00001 The second vulnerability
-bar  0.1     VULN-2              CVE-0000-00002 The third vulnerability"""
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")} The first vulnerability
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0          {_V("CVE-0000-00001")} The second vulnerability
+{_P("bar")}  0.1     {_V("VULN-2")}              {_V("CVE-0000-00002")} The third vulnerability"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_no_desc(vuln_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = """Name Version ID     Fix Versions Aliases
+    expected_columns = f"""Name Version ID     Fix Versions Aliases
 ---- ------- ------ ------------ --------------
-foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000
-foo  1.0     VULN-1 1.0          CVE-0000-00001
-bar  0.1     VULN-2              CVE-0000-00002"""
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0          {_V("CVE-0000-00001")}
+{_P("bar")}  0.1     {_V("VULN-2")}              {_V("CVE-0000-00002")}"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_no_desc_no_aliases(vuln_data):
     columns_format = format.ColumnsFormat(False, False)
-    expected_columns = """Name Version ID     Fix Versions
+    expected_columns = f"""Name Version ID     Fix Versions
 ---- ------- ------ ------------
-foo  1.0     VULN-0 1.1,1.4
-foo  1.0     VULN-1 1.0
-bar  0.1     VULN-2"""
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0
+{_P("bar")}  0.1     {_V("VULN-2")}"""
     assert columns_format.format(vuln_data, []) == expected_columns
 
 
 def test_columns_skipped_dep(vuln_data_skipped_dep):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = """Name Version ID     Fix Versions Aliases
+    expected_columns = f"""Name Version ID     Fix Versions Aliases
 ---- ------- ------ ------------ --------------
-foo  1.0     VULN-0 1.1,1.4      CVE-0000-00000
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      {_V("CVE-0000-00000")}
 Name Skip Reason
 ---- -----------
 bar  skip-reason"""
@@ -66,19 +76,19 @@ bar  skip-reason"""
 
 def test_columns_fix(vuln_data, fix_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = """Name Version ID     Fix Versions Applied Fix                            Aliases
+    expected_columns = f"""Name Version ID     Fix Versions Applied Fix                            Aliases
 ---- ------- ------ ------------ -------------------------------------- --------------
-foo  1.0     VULN-0 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) CVE-0000-00000
-foo  1.0     VULN-1 1.0          Successfully upgraded foo (1.0 => 1.8) CVE-0000-00001
-bar  0.1     VULN-2              Successfully upgraded bar (0.1 => 0.3) CVE-0000-00002"""
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00000")}
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0          Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00001")}
+{_P("bar")}  0.1     {_V("VULN-2")}              Successfully upgraded bar (0.1 => 0.3) {_V("CVE-0000-00002")}"""
     assert columns_format.format(vuln_data, fix_data) == expected_columns
 
 
 def test_columns_skipped_fix(vuln_data, skipped_fix_data):
     columns_format = format.ColumnsFormat(False, True)
-    expected_columns = """Name Version ID     Fix Versions Applied Fix                            Aliases
+    expected_columns = f"""Name Version ID     Fix Versions Applied Fix                            Aliases
 ---- ------- ------ ------------ -------------------------------------- --------------
-foo  1.0     VULN-0 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) CVE-0000-00000
-foo  1.0     VULN-1 1.0          Successfully upgraded foo (1.0 => 1.8) CVE-0000-00001
-bar  0.1     VULN-2              Failed to fix bar (0.1): skip-reason   CVE-0000-00002"""
+{_P("foo")}  1.0     {_V("VULN-0")} 1.1,1.4      Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00000")}
+{_P("foo")}  1.0     {_V("VULN-1")} 1.0          Successfully upgraded foo (1.0 => 1.8) {_V("CVE-0000-00001")}
+{_P("bar")}  0.1     {_V("VULN-2")}              Failed to fix bar (0.1): skip-reason   {_V("CVE-0000-00002")}"""
     assert columns_format.format(vuln_data, skipped_fix_data) == expected_columns

--- a/test/format/test_columns.py
+++ b/test/format/test_columns.py
@@ -1,16 +1,17 @@
 import pytest
 
 import pip_audit._format as format
-from pip_audit._format.columns import _osc8_link, _pypi_url, _vuln_id_url
+from pip_audit._format.columns import _osc8_link
+from pip_audit._format.interface import pypi_url, vuln_id_url
 
 
 # Shortcuts for building expected output with OSC8 links
 def _P(name):
-    return _osc8_link(name, _pypi_url(name))
+    return _osc8_link(name, pypi_url(name))
 
 
 def _V(vid):
-    return _osc8_link(vid, _vuln_id_url(vid))
+    return _osc8_link(vid, vuln_id_url(vid))
 
 
 @pytest.mark.parametrize("output_desc, output_aliases", ([True, False], [True, False]))

--- a/test/format/test_markdown.py
+++ b/test/format/test_markdown.py
@@ -1,6 +1,17 @@
 import pytest
 
 import pip_audit._format as format
+from pip_audit._format.interface import pypi_url, vuln_id_url
+from pip_audit._format.markdown import _md_link
+
+
+# Shortcuts for building expected output with Markdown links
+def _P(name):
+    return _md_link(name, pypi_url(name))
+
+
+def _V(vid):
+    return _md_link(vid, vuln_id_url(vid))
 
 
 @pytest.mark.parametrize("output_desc, output_aliases", ([True, False], [True, False]))
@@ -11,43 +22,43 @@ def test_columns_not_manifest(output_desc, output_aliases):
 
 def test_markdown(vuln_data):
     markdown_format = format.MarkdownFormat(True, True)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions | Aliases | Description
 --- | --- | --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4 | CVE-0000-00000 | The first vulnerability
-foo | 1.0 | VULN-1 | 1.0 | CVE-0000-00001 | The second vulnerability
-bar | 0.1 | VULN-2 |  | CVE-0000-00002 | The third vulnerability"""
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4 | {_V("CVE-0000-00000")} | The first vulnerability
+{_P("foo")} | 1.0 | {_V("VULN-1")} | 1.0 | {_V("CVE-0000-00001")} | The second vulnerability
+{_P("bar")} | 0.1 | {_V("VULN-2")} |  | {_V("CVE-0000-00002")} | The third vulnerability"""
     assert markdown_format.format(vuln_data, []) == expected_markdown
 
 
 def test_markdown_no_desc(vuln_data):
     markdown_format = format.MarkdownFormat(False, True)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions | Aliases
 --- | --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4 | CVE-0000-00000
-foo | 1.0 | VULN-1 | 1.0 | CVE-0000-00001
-bar | 0.1 | VULN-2 |  | CVE-0000-00002"""
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4 | {_V("CVE-0000-00000")}
+{_P("foo")} | 1.0 | {_V("VULN-1")} | 1.0 | {_V("CVE-0000-00001")}
+{_P("bar")} | 0.1 | {_V("VULN-2")} |  | {_V("CVE-0000-00002")}"""
     assert markdown_format.format(vuln_data, []) == expected_markdown
 
 
 def test_markdown_no_desc_no_aliases(vuln_data):
     markdown_format = format.MarkdownFormat(False, False)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions
 --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4
-foo | 1.0 | VULN-1 | 1.0
-bar | 0.1 | VULN-2 | """
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4
+{_P("foo")} | 1.0 | {_V("VULN-1")} | 1.0
+{_P("bar")} | 0.1 | {_V("VULN-2")} | """
     assert markdown_format.format(vuln_data, []) == expected_markdown
 
 
 def test_markdown_skipped_dep(vuln_data_skipped_dep):
     markdown_format = format.MarkdownFormat(False, True)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions | Aliases
 --- | --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4 | CVE-0000-00000
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4 | {_V("CVE-0000-00000")}
 
 Name | Skip Reason
 --- | ---
@@ -72,21 +83,21 @@ bar | skip-reason"""
 
 def test_markdown_fix(vuln_data, fix_data):
     markdown_format = format.MarkdownFormat(False, True)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions | Applied Fix | Aliases
 --- | --- | --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4 | Successfully upgraded foo (1.0 => 1.8) | CVE-0000-00000
-foo | 1.0 | VULN-1 | 1.0 | Successfully upgraded foo (1.0 => 1.8) | CVE-0000-00001
-bar | 0.1 | VULN-2 |  | Successfully upgraded bar (0.1 => 0.3) | CVE-0000-00002"""
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4 | Successfully upgraded foo (1.0 => 1.8) | {_V("CVE-0000-00000")}
+{_P("foo")} | 1.0 | {_V("VULN-1")} | 1.0 | Successfully upgraded foo (1.0 => 1.8) | {_V("CVE-0000-00001")}
+{_P("bar")} | 0.1 | {_V("VULN-2")} |  | Successfully upgraded bar (0.1 => 0.3) | {_V("CVE-0000-00002")}"""
     assert markdown_format.format(vuln_data, fix_data) == expected_markdown
 
 
 def test_markdown_skipped_fix(vuln_data, skipped_fix_data):
     markdown_format = format.MarkdownFormat(False, True)
-    expected_markdown = """
+    expected_markdown = f"""
 Name | Version | ID | Fix Versions | Applied Fix | Aliases
 --- | --- | --- | --- | --- | ---
-foo | 1.0 | VULN-0 | 1.1,1.4 | Successfully upgraded foo (1.0 => 1.8) | CVE-0000-00000
-foo | 1.0 | VULN-1 | 1.0 | Successfully upgraded foo (1.0 => 1.8) | CVE-0000-00001
-bar | 0.1 | VULN-2 |  | Failed to fix bar (0.1): skip-reason | CVE-0000-00002"""
+{_P("foo")} | 1.0 | {_V("VULN-0")} | 1.1,1.4 | Successfully upgraded foo (1.0 => 1.8) | {_V("CVE-0000-00000")}
+{_P("foo")} | 1.0 | {_V("VULN-1")} | 1.0 | Successfully upgraded foo (1.0 => 1.8) | {_V("CVE-0000-00001")}
+{_P("bar")} | 0.1 | {_V("VULN-2")} |  | Failed to fix bar (0.1): skip-reason | {_V("CVE-0000-00002")}"""
     assert markdown_format.format(vuln_data, skipped_fix_data) == expected_markdown


### PR DESCRIPTION
Gives output like this, where:

* pygments links to https://pypi.org/project/Pygments/
* CVE-2026-4539 links to https://osv.dev/vulnerability/CVE-2026-4539
* GHSA-5239-wwwm-4pmq links to https://osv.dev/vulnerability/GHSA-5239-wwwm-4pmq

<img width="694" height="187" alt="image" src="https://github.com/user-attachments/assets/44b71ab5-1fed-4859-a50b-b8b7453d5a72" />

I didn't link the skipped packages because maybe they were installed from another index.

(In my case, they're editable installs of PyPI packages with dev versions.)

Also add a newline between the tables for readability.