### PR TITLE
Add environment variable support for --ignore-vuln

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -378,7 +378,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         metavar="ID",
         action="append",
         dest="ignore_vulns",
-        default=[],
+        default=os.environ.get("PIP_AUDIT_IGNORE_VULN", "").split(),
         help=(
             "ignore a specific vulnerability by its vulnerability ID; "
             "this option can be used multiple times"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -222,9 +222,11 @@ def test_environment_variable(monkeypatch):
     monkeypatch.setenv("PIP_AUDIT_OUTPUT", "/tmp/fake")
     monkeypatch.setenv("PIP_AUDIT_PROGRESS_SPINNER", "off")
     monkeypatch.setenv("PIP_AUDIT_VULNERABILITY_SERVICE", "osv")
+    monkeypatch.setenv("PIP_AUDIT_IGNORE_VULN", "GHSA-AAAA-BBBB-CCCC GHSA-DDDD-EEEE-FFFF")
 
     parser = pip_audit._cli._parser()
     monkeypatch.setattr(pip_audit._cli, "_parse_args", lambda *a: parser.parse_args([]))
+
     args = pip_audit._cli._parse_args(parser, [])
 
     assert args.desc == VulnerabilityDescriptionChoice.Off
@@ -232,3 +234,7 @@ def test_environment_variable(monkeypatch):
     assert args.output == Path("/tmp/fake")
     assert not args.progress_spinner
     assert args.vulnerability_service == VulnerabilityServiceChoice.Osv
+    assert args.ignore_vulns == [
+        "GHSA-AAAA-BBBB-CCCC",
+        "GHSA-DDDD-EEEE-FFFF",
+    ]


### PR DESCRIPTION
## Summary
This PR adds support for the `PIP_AUDIT_IGNORE_VULN` environment variable.

## What changed
- added a CLI test covering `PIP_AUDIT_IGNORE_VULN`
- updated `--ignore-vuln` to read its default from the environment when set

## Why
Fixes #948.

## Notes
The environment variable mirrors `--ignore-vuln` and accepts a space-separated list of vulnerability IDs.