### PR TITLE
fix: skip editable requirements before inferred hash validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed `--skip-editable` handling for `--disable-pip` when hashed requirements
+  infer `--require-hashes`, allowing editable requirements to be skipped before
+  hash validation
+  ([#1024](https://github.com/pypa/pip-audit/issues/1024))
+
 ## [2.10.0]
 
 ### Added

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -300,6 +300,12 @@ class RequirementSource(DependencySource):
         """
         req_specifiers: dict[str, SpecifierSet] = {}
         for req in reqs:
+            if self._skip_editable and req.is_editable:
+                yield SkippedDependency(
+                    name=req.name or req.requirement_line.line,
+                    skip_reason="requirement marked as editable",
+                )
+                continue
             if not req.hash_options and require_hashes:
                 raise RequirementSourceError(f"requirement {req.dumps()} does not contain a hash")
             if req.req is None:
@@ -314,8 +320,6 @@ class RequirementSource(DependencySource):
                     skip_reason="could not deduce package version from URL requirement",
                 )
                 continue
-            if self._skip_editable and req.is_editable:
-                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
             if req.marker is not None and not req.marker.evaluate():
                 # TODO(ww): Remove this `no cover` pragma once we're 3.10+.
                 # See: https://github.com/nedbat/coveragepy/issues/198

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -517,8 +517,29 @@ def test_requirement_source_disable_pip_editable_skip(req_file):
         skip_editable=True,
     )
 
-    specs = list(source.collect())
-    assert SkippedDependency(name="flask", skip_reason="requirement marked as editable") in specs
+    assert list(source.collect()) == [
+        SkippedDependency(name="flask", skip_reason="requirement marked as editable")
+    ]
+
+
+def test_requirement_source_disable_pip_editable_skip_with_inferred_hashes(req_file):
+    source = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:.\n"
+                "requests==2.31.0 "
+                "--hash=sha256:58cd2187c01e70e6e26505bca751777a74f336f717b0f37c29e2f6cfa6d1f936",
+            )
+        ],
+        disable_pip=True,
+        skip_editable=True,
+    )
+
+    assert list(source.collect()) == [
+        SkippedDependency(name="-e file:.", skip_reason="requirement marked as editable"),
+        ResolvedDependency("requests", Version("2.31.0")),
+    ]
 
 
 def test_requirement_source_disable_pip_duplicate_dependencies(req_file):


### PR DESCRIPTION
## Summary
- skip editable requirements before enforcing inferred hash checks in the `--disable-pip` path
- add regression coverage for hashed requirements combined with `--skip-editable`
- avoid yielding an extra URL-skip result for editable requirements that are explicitly skipped

## Testing
- `pytest test/dependency_source/test_requirement.py -q`
- `ruff check pip_audit/_dependency_source/requirement.py test/dependency_source/test_requirement.py CHANGELOG.md`
