### PR TITLE
Use PIPAPI_PYTHON_LOCATION when fixing dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `pip-audit --fix` now respects `PIPAPI_PYTHON_LOCATION` when invoking
+  `pip` ([#1030](https://github.com/pypa/pip-audit/issues/1030)).
+
 ## [2.10.0]
 
 ### Added

--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -142,8 +142,9 @@ class PipSource(DependencySource):
         self.state.update_state(
             f"Fixing {fix_version.dep.name} ({fix_version.dep.version} => {fix_version.version})"
         )
+        effective_python = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
         fix_cmd = [
-            sys.executable,
+            effective_python,
             "-m",
             "pip",
             "install",

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -167,6 +167,25 @@ def test_pip_source_fix(monkeypatch):
     source.fix(fix_version)
 
 
+def test_pip_source_fix_uses_pipapi_python_location(monkeypatch):
+    python_location = "/definitely/fake/path/python"
+    monkeypatch.setenv("PIPAPI_PYTHON_LOCATION", python_location)
+
+    source = pip.PipSource()
+
+    fix_version = ResolvedFixVersion(
+        dep=ResolvedDependency(name="pip-api", version=Version("1.0")),
+        version=Version("1.5"),
+    )
+
+    def run_mock(args, **kwargs):
+        assert " ".join(args) == f"{python_location} -m pip install pip-api==1.5"
+
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    source.fix(fix_version)
+
+
 def test_pip_source_fix_failure(monkeypatch):
     source = pip.PipSource()
 


### PR DESCRIPTION
Fixes #1030.

This updates `PipSource.fix()` to use `PIPAPI_PYTHON_LOCATION` when it is set, matching the effective Python behavior already used elsewhere in `PipSource`.

I added regression coverage for the generated pip install command.

Tests:
- `python -m pytest test/dependency_source/test_pip.py -k "fix"`
- `python -m pytest test/dependency_source/test_pip.py`
- `python -m ruff check pip_audit/_dependency_source/pip.py test/dependency_source/test_pip.py`
- `git diff --check`