### PR TITLE
Skip editable requirements before hash validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `pip-audit --skip-editable` now skips editable requirements before enforcing
+  hash validation ([#1024](https://github.com/pypa/pip-audit/issues/1024)).
+
 ## [2.10.0]
 
 ### Added

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -300,6 +300,9 @@ class RequirementSource(DependencySource):
         """
         req_specifiers: dict[str, SpecifierSet] = {}
         for req in reqs:
+            if self._skip_editable and req.is_editable:
+                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
+                continue
             if not req.hash_options and require_hashes:
                 raise RequirementSourceError(f"requirement {req.dumps()} does not contain a hash")
             if req.req is None:
@@ -314,8 +317,6 @@ class RequirementSource(DependencySource):
                     skip_reason="could not deduce package version from URL requirement",
                 )
                 continue
-            if self._skip_editable and req.is_editable:
-                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
             if req.marker is not None and not req.marker.evaluate():
                 # TODO(ww): Remove this `no cover` pragma once we're 3.10+.
                 # See: https://github.com/nedbat/coveragepy/issues/198

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -800,6 +800,27 @@ def test_requirement_source_disable_pip_hashes_without_no_deps(req_file):
     assert specs == [ResolvedDependency("flask", Version("2.0.1"))]
 
 
+def test_requirement_source_skip_editable_before_hash_validation(req_file):
+    source = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:flask.py#egg=flask==2.0.1\n"
+                "requests==1.0 "
+                "--hash=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
+        ],
+        disable_pip=True,
+        skip_editable=True,
+    )
+
+    specs = list(source.collect())
+    assert specs == [
+        SkippedDependency(name="flask", skip_reason="requirement marked as editable"),
+        ResolvedDependency("requests", Version("1.0")),
+    ]
+
+
 def test_requirement_source_disable_pip_incomplete_hashes(req_file):
     # In this case, `--no-deps` is not provided but since the requirements file is hashed, providing
     # `--disable-pip` is valid.


### PR DESCRIPTION
Fixes #1024.

This skips editable requirements before enforcing hash validation when
`--skip-editable` is enabled.

Non-editable requirements still keep the existing hash validation behavior.

Tests:
- `python -m pytest test/dependency_source/test_requirement.py -k "editable and hash"`
- `python -m pytest test/dependency_source/test_requirement.py -k "skip_editable_before_hash_validation or disable_pip_editable_skip or disable_pip_incomplete_hashes or require_hashes_inferred" --skip-online`
- `python -m ruff check pip_audit/_dependency_source/requirement.py test/dependency_source/test_requirement.py`
- `git diff --check`