### PR TITLE
_subprocess: decode only complete UTF-8 codepoints in progress output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed live progress output emitting replacement characters when a subprocess's
+  stdout split a multi-byte UTF-8 sequence across reads. The poll-buffer loop now
+  decodes incrementally and only surfaces complete codepoints
+  ([#574](https://github.com/pypa/pip-audit/issues/574))
+
 ## [2.10.0]
 
 ### Added

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -3,6 +3,7 @@ A thin `subprocess` wrapper for making long-running subprocesses more
 responsive from the `pip-audit` CLI.
 """
 
+import codecs
 import os.path
 import subprocess
 from collections.abc import Sequence
@@ -43,6 +44,18 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
     stdout = b""
     stderr = b""
 
+    # We accumulate raw bytes for the final result, but the live progress
+    # updates need a textual view of `stdout` so far. Decoding the raw buffer
+    # on each iteration is unsound: an unbuffered read can stop in the middle
+    # of a multi-byte UTF-8 sequence, so a plain `bytes.decode` would either
+    # raise or (with `errors="replace"`) emit a replacement character for a
+    # codepoint that is actually valid once the rest of its bytes arrive.
+    # An incremental decoder holds those trailing bytes back until the
+    # sequence is complete, so we only ever surface fully-decoded codepoints.
+    # See https://github.com/pypa/pip-audit/issues/574.
+    stdout_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    decoded_stdout = ""
+
     # Run the process with unbuffered I/O, to make the poll-and-read loop below
     # more responsive.
     with Popen(args, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
@@ -51,12 +64,19 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
         # once `stdout` hits EOF, so we don't have to worry about that blocking.
         while not terminated:
             terminated = process.poll() is not None
-            stdout += process.stdout.read()  # type: ignore
+            chunk = process.stdout.read()  # type: ignore
+            stdout += chunk
             stderr += process.stderr.read()  # type: ignore
-            state.update_state(
-                f"Running {pretty_args}",
-                stdout.decode(errors="replace") if log_stdout else None,
-            )
+            if log_stdout:
+                # `final=terminated` flushes any pending (incomplete) bytes once
+                # the stream is at EOF, matching the previous replace behaviour.
+                decoded_stdout += stdout_decoder.decode(chunk, final=terminated)
+                state.update_state(
+                    f"Running {pretty_args}",
+                    decoded_stdout,
+                )
+            else:
+                state.update_state(f"Running {pretty_args}")
 
         if process.returncode != 0:
             raise CalledProcessError(

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -1,8 +1,94 @@
+import sys
+
 import pytest
 
+from pip_audit import _subprocess
+from pip_audit._state import AuditState
 from pip_audit._subprocess import CalledProcessError, run
 
 
 def test_run_raises():
     with pytest.raises(CalledProcessError):
         run(["false"])
+
+
+class _RecordingState(AuditState):
+    def __init__(self):
+        super().__init__()
+        self.logs = []
+
+    def update_state(self, message, logs=None):
+        self.logs.append(logs)
+
+
+class _FakeStream:
+    """A byte stream that hands back pre-split chunks one `read()` at a time."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def read(self, *args):
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+
+class _FakeProcess:
+    """A minimal `Popen` stand-in driven by scripted stdout chunks."""
+
+    def __init__(self, stdout_chunks):
+        # One extra poll cycle after the last chunk so EOF is observed.
+        self.stdout = _FakeStream(stdout_chunks + [b""])
+        self.stderr = _FakeStream([])
+        self.returncode = 0
+        self._polls = len(stdout_chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def poll(self):
+        # Stay alive while there are still scripted chunks to read, so the loop
+        # processes each chunk in its own iteration (matching unbuffered reads).
+        if self._polls > 0:
+            self._polls -= 1
+            return None
+        return 0
+
+
+def test_run_decodes_multibyte_utf8_split_across_reads(monkeypatch):
+    # U+20AC (Euro sign) is 0xE2 0x82 0xAC in UTF-8. Split it across two reads
+    # so each individual read carries an incomplete codepoint. This is the
+    # exact unsound condition from https://github.com/pypa/pip-audit/issues/574.
+    chunks = [b"\xe2\x82", b"\xac"]
+
+    def fake_popen(*args, **kwargs):
+        return _FakeProcess(chunks)
+
+    monkeypatch.setattr(_subprocess, "Popen", fake_popen)
+
+    state = _RecordingState()
+    out = run(["pip"], log_stdout=True, state=state)
+
+    # The final result must be the exact codepoint, never a replacement char.
+    assert out == "€"
+    assert "�" not in out
+
+    # No live progress update may expose a replacement character: the first
+    # read held an incomplete sequence, which the incremental decoder must
+    # buffer rather than surface as U+FFFD.
+    for logs in state.logs:
+        if logs is not None:
+            assert "�" not in logs
+    assert any(logs == "€" for logs in state.logs)
+
+
+def test_run_decodes_multibyte_utf8_end_to_end():
+    # End-to-end smoke test through a real subprocess: emit a multi-byte
+    # codepoint and confirm `run` returns it intact.
+    program = "import sys; sys.stdout.buffer.write('€'.encode('utf-8'))\n"
+    out = run([sys.executable, "-c", program])
+    assert out == "€"
+    assert "�" not in out


### PR DESCRIPTION
Fixes #574.

#572 fixed the crash on the final decode, but as #573 showed, the
poll-and-read loop in `_subprocess.run` is still unsound for the live
progress output. The loop reads `stdout` unbuffered, so a read can land in
the middle of a multi-byte UTF-8 sequence. Each iteration then decoded the
whole accumulated buffer with `errors="replace"`, which turns a codepoint
that is actually valid (once the rest of its bytes arrive on the next read)
into a U+FFFD replacement character in the progress stream.

Following the maintainer's note on the issue, the right fix is to stop
decoding partial byte sequences. Rather than switch wholesale to
`Popen.communicate()` (which would drop the incremental progress updates
that this wrapper exists to provide), this keeps the poll/read loop and its
responsiveness intact and feeds each chunk through a
`codecs.getincrementaldecoder("utf-8")`. The incremental decoder buffers an
incomplete trailing sequence until it is complete, so the progress output
only ever sees fully-decoded codepoints. `final=True` is passed once the
stream hits EOF to flush any genuinely-truncated bytes, preserving the
previous replace behaviour for malformed input. The final result decode is
unchanged.

### Testing

Added a regression in `test/test_subprocess.py` that drives `run` with a
scripted process whose stdout splits the Euro sign (U+20AC, `e2 82 ac`)
across two reads, so the first read carries an incomplete codepoint. It
asserts that no progress update contains a replacement character and that
the final output is exactly `€`. The test fails on the previous code (the
first progress update is `�`) and passes with this change. A second
end-to-end test runs a real subprocess emitting the codepoint and confirms
`run` returns it intact.

`make lint` (ruff format/check, mypy, interrogate, typos) is clean.

### Changelog

Added an entry under `[Unreleased]` / `Fixed`.
