### PR TITLE
docs: scope pre-commit hook to requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,16 @@ For example, using `pip-audit` via `pre-commit` to audit a requirements file:
     hooks:
       -   id: pip-audit
           args: ["-r", "requirements.txt"]
+          files: ^requirements\.txt$
 
 ci:
   # Leave pip-audit to only run locally and not in CI
   # pre-commit.ci does not allow network calls
   skip: [pip-audit]
 ```
+
+The `files` pattern keeps the hook focused on changes to the requirements file being
+audited. Adjust the pattern if your project stores dependency files elsewhere.
 
 Any `pip-audit` arguments documented below can be passed.
 


### PR DESCRIPTION
### Summary
- add a `files` filter to the documented pre-commit hook example
- explain that the pattern should match the dependency file being audited

### Why
This keeps the hook from running on every commit when the audited requirements file was not changed.

Fixes #334.

### Checks
- `git diff --check`