### PR TITLE
feat: support PIP_AUDIT_IGNORE_VULN environment variable for --ignore-vuln

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -378,10 +378,12 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         metavar="ID",
         action="append",
         dest="ignore_vulns",
-        default=[],
+        default=list(filter(None, os.environ.get("PIP_AUDIT_IGNORE_VULN", "").split())),
         help=(
             "ignore a specific vulnerability by its vulnerability ID; "
-            "this option can be used multiple times"
+            "this option can be used multiple times; "
+            "may also be set via the PIP_AUDIT_IGNORE_VULN environment variable "
+            "as a space-separated list of IDs"
         ),
     )
     parser.add_argument(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -232,3 +232,35 @@ def test_environment_variable(monkeypatch):
     assert args.output == Path("/tmp/fake")
     assert not args.progress_spinner
     assert args.vulnerability_service == VulnerabilityServiceChoice.Osv
+
+
+def test_pip_audit_ignore_vuln_env_var(monkeypatch):
+    """PIP_AUDIT_IGNORE_VULN sets the default ignore list from the environment."""
+    monkeypatch.setenv("PIP_AUDIT_IGNORE_VULN", "GHSA-1234-5678-abcd PYSEC-2024-001")
+
+    parser = pip_audit._cli._parser()
+    args = parser.parse_args([])
+
+    assert "GHSA-1234-5678-abcd" in args.ignore_vulns
+    assert "PYSEC-2024-001" in args.ignore_vulns
+
+
+def test_pip_audit_ignore_vuln_env_var_combined_with_cli(monkeypatch):
+    """PIP_AUDIT_IGNORE_VULN env var IDs are combined with --ignore-vuln CLI flags."""
+    monkeypatch.setenv("PIP_AUDIT_IGNORE_VULN", "GHSA-1111-2222-aaaa")
+
+    parser = pip_audit._cli._parser()
+    args = parser.parse_args(["--ignore-vuln", "GHSA-3333-4444-bbbb"])
+
+    assert "GHSA-1111-2222-aaaa" in args.ignore_vulns
+    assert "GHSA-3333-4444-bbbb" in args.ignore_vulns
+
+
+def test_pip_audit_ignore_vuln_env_var_empty(monkeypatch):
+    """Empty PIP_AUDIT_IGNORE_VULN produces an empty default list."""
+    monkeypatch.setenv("PIP_AUDIT_IGNORE_VULN", "")
+
+    parser = pip_audit._cli._parser()
+    args = parser.parse_args([])
+
+    assert args.ignore_vulns == []


### PR DESCRIPTION
Closes #948.

## Summary

Adds `PIP_AUDIT_IGNORE_VULN` environment variable support, mirroring the existing `--ignore-vuln` flag. IDs in the env var are read as a space-separated list and used as the default for `--ignore-vuln`. CLI flags and env var IDs are merged, so both can be used at the same time.

This follows the same pattern already used by other `pip-audit` env vars (`PIP_AUDIT_OUTPUT`, `PIP_AUDIT_DESC`, etc.).

## Usage

```bash
# Single ID
PIP_AUDIT_IGNORE_VULN=GHSA-1234-5678-abcd pip-audit

# Multiple IDs (space-separated)
PIP_AUDIT_IGNORE_VULN="GHSA-1234-5678-abcd PYSEC-2024-001" pip-audit

# Combined with --ignore-vuln (all IDs are merged)
PIP_AUDIT_IGNORE_VULN=GHSA-1234-5678-abcd pip-audit --ignore-vuln PYSEC-2024-001
```

## Changes

- `pip_audit/_cli.py`: change `--ignore-vuln` default from `[]` to `list(filter(None, os.environ.get("PIP_AUDIT_IGNORE_VULN", "").split()))`
- `pip_audit/_cli.py`: update help text to document the env var
- `test/test_cli.py`: add three tests — single env var, combined env var + CLI flag, and empty env var

## Test plan

- [ ] `test_pip_audit_ignore_vuln_env_var` — env var IDs appear in `args.ignore_vulns`
- [ ] `test_pip_audit_ignore_vuln_env_var_combined_with_cli` — env var and CLI IDs are merged
- [ ] `test_pip_audit_ignore_vuln_env_var_empty` — empty env var produces empty default list
- [ ] All existing tests pass