### PR TITLE
Respect PIPAPI_PYTHON_LOCATION for --fix installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `pip-audit --fix` now respects `PIPAPI_PYTHON_LOCATION`, matching the
+  Python selection behavior used during dependency collection
+  ([#1030](https://github.com/pypa/pip-audit/issues/1030))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -142,8 +142,9 @@ class PipSource(DependencySource):
         self.state.update_state(
             f"Fixing {fix_version.dep.name} ({fix_version.dep.version} => {fix_version.version})"
         )
+        effective_python = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
         fix_cmd = [
-            sys.executable,
+            effective_python,
             "-m",
             "pip",
             "install",

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -183,3 +183,21 @@ def test_pip_source_fix_failure(monkeypatch):
 
     with pytest.raises(pip.PipFixError):
         source.fix(fix_version)
+
+
+def test_pip_source_fix_uses_pipapi_python_location(monkeypatch):
+    source = pip.PipSource()
+
+    fix_version = ResolvedFixVersion(
+        dep=ResolvedDependency(name="pip-api", version=Version("1.0")),
+        version=Version("1.5"),
+    )
+
+    monkeypatch.setenv("PIPAPI_PYTHON_LOCATION", "/tmp/custom-python")
+
+    def run_mock(args, **kwargs):
+        assert " ".join(args) == "/tmp/custom-python -m pip install pip-api==1.5"
+
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    source.fix(fix_version)


### PR DESCRIPTION
Fixes #1030.

PipSource.fix() still invoked pip via sys.executable, so pip-audit --fix ignored PIPAPI_PYTHON_LOCATION even though collection already respects it.

This uses the same effective interpreter selection in fix() and adds regression coverage for the environment-variable override path.

Verification:
- python3.12 -m venv .venv && .venv/bin/python -m pip install -e '.[dev]'
- .venv/bin/python -m pytest test/dependency_source/test_pip.py -k "fix"
- .venv/bin/python -m pytest test/dependency_source/test_pip.py
- .venv/bin/python -m ruff check pip_audit/_dependency_source/pip.py test/dependency_source/test_pip.py