### PR TITLE
Skip editable requirements before hash checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `--skip-editable` now skips editable requirements before enforcing hashes,
+  so hashed requirements files can include editable entries when dependency
+  resolution is disabled ([#1024](https://github.com/pypa/pip-audit/issues/1024))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -300,6 +300,13 @@ class RequirementSource(DependencySource):
         """
         req_specifiers: dict[str, SpecifierSet] = {}
         for req in reqs:
+            if self._skip_editable and req.is_editable:
+                yield SkippedDependency(
+                    name=req.name or req.requirement_line.line,
+                    skip_reason="requirement marked as editable",
+                )
+                continue
+
             if not req.hash_options and require_hashes:
                 raise RequirementSourceError(f"requirement {req.dumps()} does not contain a hash")
             if req.req is None:
@@ -314,8 +321,6 @@ class RequirementSource(DependencySource):
                     skip_reason="could not deduce package version from URL requirement",
                 )
                 continue
-            if self._skip_editable and req.is_editable:
-                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
             if req.marker is not None and not req.marker.evaluate():
                 # TODO(ww): Remove this `no cover` pragma once we're 3.10+.
                 # See: https://github.com/nedbat/coveragepy/issues/198

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -522,6 +522,27 @@ def test_requirement_source_disable_pip_editable_skip(req_file):
     assert SkippedDependency(name="flask", skip_reason="requirement marked as editable") in specs
 
 
+def test_requirement_source_disable_pip_skips_editable_without_hash(req_file):
+    source = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:.\n"
+                "wheel==0.38.1 "
+                "--hash=sha256:7a95f9a8dc0924ef318bd55b616112c70903192f524d120acc614f59547a9e1f",
+            )
+        ],
+        disable_pip=True,
+        no_deps=True,
+        skip_editable=True,
+    )
+
+    assert list(source.collect()) == [
+        SkippedDependency(name="-e file:.", skip_reason="requirement marked as editable"),
+        ResolvedDependency(name="wheel", version=Version("0.38.1")),
+    ]
+
+
 def test_requirement_source_disable_pip_duplicate_dependencies(req_file):
     source = _init_requirement(
         [(req_file(), "flask==1.0\nflask==1.0")], disable_pip=True, no_deps=True


### PR DESCRIPTION
Editable requirements are currently checked for hashes before `--skip-editable` is applied. In a requirements file where another requirement includes a hash, hash checking is inferred for the whole file, so an editable entry like `-e file:.` fails before it can be skipped.

This moves the editable skip to the start of pre-resolved dependency collection and stops processing that requirement after yielding the skipped dependency. For editable requirements without an `#egg` name, the original requirement line is used in the skipped dependency message.

fixes #1024

Tests:
- `python -m pytest test/dependency_source/test_requirement.py::test_requirement_source_disable_pip_skips_editable_without_hash test/dependency_source/test_requirement.py::test_requirement_source_disable_pip_editable_skip test/dependency_source/test_requirement.py::test_requirement_source_disable_pip_incomplete_hashes test/dependency_source/test_requirement.py::test_requirement_source_disable_pip_editable_without_egg_fragment -q`
- `python -m pytest -m "not online" -q`
- `python -m ruff check pip_audit/_dependency_source/requirement.py test/dependency_source/test_requirement.py`
- `python -m mypy pip_audit`