### PR TITLE
Respect PIPAPI_PYTHON_LOCATION when fixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `--fix` now respects `PIPAPI_PYTHON_LOCATION` when upgrading packages from
+  `PipSource`, matching the interpreter used by `pip-api`
+  ([#1030](https://github.com/pypa/pip-audit/issues/1030))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -142,8 +142,9 @@ class PipSource(DependencySource):
         self.state.update_state(
             f"Fixing {fix_version.dep.name} ({fix_version.dep.version} => {fix_version.version})"
         )
+        effective_python = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
         fix_cmd = [
-            sys.executable,
+            effective_python,
             "-m",
             "pip",
             "install",

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -152,6 +152,7 @@ def test_pip_source_skips_editable(monkeypatch):
 
 
 def test_pip_source_fix(monkeypatch):
+    monkeypatch.delenv("PIPAPI_PYTHON_LOCATION", raising=False)
     source = pip.PipSource()
 
     fix_version = ResolvedFixVersion(
@@ -167,7 +168,25 @@ def test_pip_source_fix(monkeypatch):
     source.fix(fix_version)
 
 
+def test_pip_source_fix_uses_pipapi_python_location(monkeypatch):
+    monkeypatch.setenv("PIPAPI_PYTHON_LOCATION", "/tmp/venv/bin/python")
+    source = pip.PipSource()
+
+    fix_version = ResolvedFixVersion(
+        dep=ResolvedDependency(name="pip-api", version=Version("1.0")),
+        version=Version("1.5"),
+    )
+
+    def run_mock(args, **kwargs):
+        assert " ".join(args) == "/tmp/venv/bin/python -m pip install pip-api==1.5"
+
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    source.fix(fix_version)
+
+
 def test_pip_source_fix_failure(monkeypatch):
+    monkeypatch.delenv("PIPAPI_PYTHON_LOCATION", raising=False)
     source = pip.PipSource()
 
     fix_version = ResolvedFixVersion(


### PR DESCRIPTION
Fixes #1030.

## Summary

- use `PIPAPI_PYTHON_LOCATION` when `PipSource.fix()` invokes `python -m pip install`
- keep the current `sys.executable` fallback when the environment variable is not set
- cover both the explicit environment-variable path and the fallback path in `PipSource` tests

## Tests

- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --extra test pytest test\dependency_source\test_pip.py -q`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --extra lint ruff check pip_audit\_dependency_source\pip.py test\dependency_source\test_pip.py`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --extra lint ruff format --check pip_audit\_dependency_source\pip.py test\dependency_source\test_pip.py`
- `git diff --check`