### PR TITLE
Respect PIPAPI_PYTHON_LOCATION when fixing

### DIFF
--- a/pip_audit/_dependency_source/pip.py
+++ b/pip_audit/_dependency_source/pip.py
@@ -142,8 +142,9 @@ class PipSource(DependencySource):
         self.state.update_state(
             f"Fixing {fix_version.dep.name} ({fix_version.dep.version} => {fix_version.version})"
         )
+        effective_python = os.environ.get("PIPAPI_PYTHON_LOCATION", sys.executable)
         fix_cmd = [
-            sys.executable,
+            effective_python,
             "-m",
             "pip",
             "install",

--- a/test/dependency_source/test_pip.py
+++ b/test/dependency_source/test_pip.py
@@ -167,6 +167,24 @@ def test_pip_source_fix(monkeypatch):
     source.fix(fix_version)
 
 
+def test_pip_source_fix_respects_pipapi_python_location(monkeypatch):
+    source = pip.PipSource()
+    effective_python = "/test/.venv/bin/python"
+    monkeypatch.setenv("PIPAPI_PYTHON_LOCATION", effective_python)
+
+    fix_version = ResolvedFixVersion(
+        dep=ResolvedDependency(name="pip-api", version=Version("1.0")),
+        version=Version("1.5"),
+    )
+
+    def run_mock(args, **kwargs):
+        assert " ".join(args) == f"{effective_python} -m pip install pip-api==1.5"
+
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    source.fix(fix_version)
+
+
 def test_pip_source_fix_failure(monkeypatch):
     source = pip.PipSource()
 


### PR DESCRIPTION
## Summary

Fixes #1030.

`PipSource.__init__` already respects `PIPAPI_PYTHON_LOCATION` when determining the effective Python used by `pip-api`, but `PipSource.fix()` still invoked `sys.executable -m pip install ...`. This meant `pip-audit --fix` could update the globally installed environment instead of the target environment selected with `PIPAPI_PYTHON_LOCATION`.

This PR makes the fix path use the same environment override and adds regression coverage for the behavior.

## Validation

- `python -m pytest test/dependency_source/test_pip.py -q`
- `python -m compileall -q pip_audit test\dependency_source\test_pip.py`
- `git diff --check`