### PR TITLE
fix: skip explicit subdep fixes in unrelated req files

### DIFF
--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -206,7 +206,14 @@ class RequirementSource(DependencySource):
                         f"Fixing dependency {fix_version.dep.name} ({fix_version.dep.version} => "
                         f"{fix_version.version})"
                     )
-                    self._fix_file(filename, fix_version)
+                    self._fix_file(
+                        filename,
+                        fix_version,
+                        allow_explicit_add=len(self._filenames) == 1
+                        or self._file_contains_dependency(
+                            filename, fix_version.dep.canonical_name
+                        ),
+                    )
             except Exception as e:
                 logger.warning(
                     f"encountered an exception while applying fixes, recovering original files: {e}"
@@ -214,7 +221,20 @@ class RequirementSource(DependencySource):
                 self._recover_files(tmp_files)
                 raise e
 
-    def _fix_file(self, filename: Path, fix_version: ResolvedFixVersion) -> None:
+    def _file_contains_dependency(self, filename: Path, canonical_name: str) -> bool:
+        rf = RequirementsFile.from_file(filename)
+        for req in rf.requirements:
+            if req.req is not None and canonicalize_name(req.name) == canonical_name:
+                return True
+        return False
+
+    def _fix_file(
+        self,
+        filename: Path,
+        fix_version: ResolvedFixVersion,
+        *,
+        allow_explicit_add: bool = True,
+    ) -> None:
         # Reparse the requirements file. We want to rewrite each line to the new requirements file
         # and only modify the lines that we're fixing.
         #
@@ -269,7 +289,7 @@ class RequirementSource(DependencySource):
             # To know whether this is the case, we'll need to resolve dependencies if we haven't
             # already in order to figure out whether this subdependency belongs to this file or
             # another.
-            if not found:
+            if not found and allow_explicit_add:
                 logger.warning(
                     "added fixed subdependency explicitly to requirements file "
                     f"{filename}: {fix_version.dep.canonical_name}"

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -260,6 +260,22 @@ def test_requirement_source_fix_multiple_files(req_file):
     )
 
 
+def test_requirement_source_fix_skips_unrelated_files(req_file):
+    # Regression test for #633: don't add explicit subdependency fixes to unrelated
+    # requirements files in a layered requirements setup.
+    _check_fixes(
+        ["httpx==0.13.3", "astpretty==3.0.0"],
+        ["httpx==0.23.0", "astpretty==3.0.0"],
+        [req_file(), req_file()],
+        [
+            ResolvedFixVersion(
+                dep=ResolvedDependency(name="httpx", version=Version("0.13.3")),
+                version=Version("0.23.0"),
+            )
+        ],
+    )
+
+
 def test_requirement_source_fix_specifier_match(req_file):
     _check_fixes(
         ["flask<1.0", "requests==2.0\nflask<=0.6"],


### PR DESCRIPTION
## Summary
- When applying fixes across multiple layered requirements files, skip adding explicit subdependency pins to files that do not list the dependency
- Add regression test for the layered requirements scenario from issue 633

Fixes #633

## Test plan
- pytest test/dependency_source/test_requirement.py::test_requirement_source_fix_skips_unrelated_files
- pytest test/dependency_source/test_requirement.py::test_requirement_source_fix_explicit_subdep

Made with [Cursor](https://cursor.com)