### PR TITLE
Update ruff GitHub link to astral-sh org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ make lint
 
 `pip-audit` is automatically linted and formatted with a collection of tools:
 
-* [`ruff`](https://github.com/charliermarsh/ruff): Formatting, PEP-8 linting, style enforcement
+* [`ruff`](https://github.com/astral-sh/ruff): Formatting, PEP-8 linting, style enforcement
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage
 


### PR DESCRIPTION
Ruff moved from `charliermarsh/ruff` to `astral-sh/ruff` when its creator
founded Astral. GitHub redirects the old URL, so it wasn't broken, just
stale — updating CONTRIBUTING.md to point at the current location.

Scope note: I did a broader link scan across README.md, CONTRIBUTING.md,
and CHANGELOG.md (170 links total) while looking for this. Everything
else checked out — internal links and same-page anchors all resolve,
and the remaining external links are all live. This was the only stale
one, so keeping the PR to just this one-line fix.