### PR TITLE
fix: dedupe repeated PYSEC vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed duplicate PYSEC vulnerability entries in audit output
+  ([#1068](https://github.com/pypa/pip-audit/issues/1068))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -69,28 +69,34 @@ class Auditor:
                 unique_vulns: list[VulnerabilityResult] = []
                 seen_aliases: set[str] = set()
 
+                def add_vuln(v: VulnerabilityResult) -> None:
+                    """
+                    Add a vulnerability unless an existing result already covers one of its IDs.
+                    """
+                    if seen_aliases.intersection(v.aliases | {v.id}):
+                        idx, previous = next(
+                            (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
+                        )
+                        unique_vulns[idx] = previous.merge_aliases(v)
+                        return
+
+                    seen_aliases.update(v.aliases | {v.id})
+                    unique_vulns.append(v)
+
                 # First pass, add all PYSEC vulnerabilities and track their
                 # alias sets.
                 for v in vulns:
                     if not v.id.startswith("PYSEC"):
                         continue
 
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
+                    add_vuln(v)
 
-                # Second pass: add any non-PYSEC vulnerabilities.
+                # Second pass: add any non-PYSEC vulnerabilities, merging aliases
+                # into the PYSEC result that was added during the first pass.
                 for v in vulns:
-                    # If we've already seen this vulnerability by another name,
-                    # don't add it. Instead, find the previous result and update
-                    # its alias set.
-                    if seen_aliases.intersection(v.aliases | {v.id}):
-                        idx, previous = next(
-                            (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
-                        )
-                        unique_vulns[idx] = previous.merge_aliases(v)
+                    if v.id.startswith("PYSEC"):
                         continue
 
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
+                    add_vuln(v)
 
                 yield dep, unique_vulns

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -130,3 +130,35 @@ def test_audit_dedupes_aliases_by_id(dep_source, vulns):
 
     # The result contains the merged alias set for all aliases.
     assert results[0][1][0].aliases == {"FAKE-1", "CVE-XXXX-YYYYY"}
+
+
+def test_audit_dedupes_pysec_results_by_id(dep_source):
+    vulns = [
+        VulnerabilityResult(
+            id="PYSEC-2023-11",
+            description="first description",
+            fix_versions=[Version("1.1.0")],
+            aliases={"CVE-XXXX-YYYYY"},
+        ),
+        VulnerabilityResult(
+            id="PYSEC-2023-11",
+            description="second description",
+            fix_versions=[Version("1.1.0")],
+            aliases={"GHSA-xxxx-yyyy-zzzz"},
+        ),
+    ]
+
+    class Service(VulnerabilityService):
+        def query(self, spec):
+            return spec, vulns
+
+    service = Service()
+    source = dep_source()
+
+    auditor = Auditor(service)
+    results = list(auditor.audit(source))
+
+    assert len(results) == 1
+    assert len(results[0][1]) == 1
+    assert results[0][1][0].id == "PYSEC-2023-11"
+    assert results[0][1][0].aliases == {"CVE-XXXX-YYYYY", "GHSA-xxxx-yyyy-zzzz"}


### PR DESCRIPTION
## Summary

- dedupe repeated PYSEC vulnerability results during audit merging
- keep PYSEC-prioritized results while merging aliases from duplicate rows
- add regression coverage and a changelog entry

## Why

Fixes #1068. The PyPI vulnerability feed can return repeated rows that canonicalize to the same PYSEC ID. `pip-audit` was appending all PYSEC rows before running alias dedupe, so duplicate PYSEC vulnerabilities reached the final audit result.

## Validation

- `make test T=test/test_audit.py` - passed
- `make lint` - passed
- `make test` - passed
- branch-local `pip-audit -r <(printf 'cryptography==35.0.0\n') --progress-spinner off -f json` - exited 1 with 12 vulnerabilities and no duplicate IDs
- `git diff --check` - passed
