### PR TITLE
Support uv.lock with --locked

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -411,17 +411,28 @@ def _parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:  # pragm
 def _dep_source_from_project_path(
     project_path: Path, index_url: str, extra_index_urls: list[str], locked: bool, state: AuditState
 ) -> DependencySource:  # pragma: no cover
-    # If the user has passed `--locked`, we check for `pylock.*.toml` files.
+    # If the user has passed `--locked`, we check for supported lock files.
     if locked:
         all_pylocks = list(project_path.glob("pylock.*.toml"))
         generic_pylock = project_path / "pylock.toml"
         if generic_pylock.is_file():
             all_pylocks.append(generic_pylock)
 
-        if not all_pylocks:
-            _fatal(f"no lockfiles found in {project_path}")
+        if all_pylocks:
+            return PyLockSource(all_pylocks)
 
-        return PyLockSource(all_pylocks)
+        uv_lock = project_path / "uv.lock"
+        pyproject_path = project_path / "pyproject.toml"
+        if uv_lock.is_file() and pyproject_path.is_file():
+            return PyProjectSource(
+                pyproject_path,
+                index_url=index_url,
+                extra_index_urls=extra_index_urls,
+                locked=True,
+                state=state,
+            )
+
+        _fatal(f"no lockfiles found in {project_path}")
 
     # Check for a `pyproject.toml`
     pyproject_path = project_path / "pyproject.toml"

--- a/pip_audit/_dependency_source/pyproject.py
+++ b/pip_audit/_dependency_source/pyproject.py
@@ -38,6 +38,7 @@ class PyProjectSource(DependencySource):
         filename: Path,
         index_url: str | None = None,
         extra_index_urls: list[str] = [],
+        locked: bool = False,
         state: AuditState = AuditState(),
     ) -> None:
         """
@@ -49,9 +50,12 @@ class PyProjectSource(DependencySource):
 
         `extra_index_urls` are the extra URLs of package indexes.
 
+        `locked` prevents compatible installers from updating existing lock files.
+
         `state` is an `AuditState` to use for state callbacks.
         """
         self.filename = filename
+        self.locked = locked
         self.state = state
 
     def collect(self) -> Iterator[Dependency]:
@@ -97,9 +101,18 @@ class PyProjectSource(DependencySource):
                 # Try to install the generated requirements file.
                 ve = VirtualEnv(install_args=["-r", req_file.name], state=self.state)
                 try:
+                    old_uv_frozen = os.environ.get("UV_FROZEN")
+                    if self.locked:
+                        os.environ["UV_FROZEN"] = "1"
                     ve.create(ve_dir)
                 except VirtualEnvError as exc:
                     raise PyProjectSourceError(str(exc)) from exc
+                finally:
+                    if self.locked:
+                        if old_uv_frozen is None:
+                            os.environ.pop("UV_FROZEN", None)
+                        else:
+                            os.environ["UV_FROZEN"] = old_uv_frozen
 
                 # Now query the installed packages.
                 for name, version in ve.installed_packages:

--- a/test/dependency_source/test_pyproject.py
+++ b/test/dependency_source/test_pyproject.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pretend  # type: ignore
@@ -115,6 +116,37 @@ dependencies = [
     monkeypatch.setattr(pyproject, "VirtualEnv", MockVirtualEnv)
     with pytest.raises(DependencySourceError):
         list(source.collect())
+
+
+def test_pyproject_source_locked_sets_uv_frozen(monkeypatch, req_file):
+    class MockVirtualEnv:
+        def __init__(self, install_args: list[str], state: AuditState) -> None:
+            pass
+
+        def create(self, dir: Path) -> None:
+            assert os.environ["UV_FROZEN"] == "1"
+
+        @property
+        def installed_packages(self):
+            return []
+
+    filename = req_file()
+    with open(filename, mode="w") as f:
+        f.write(
+            """
+[project]
+dependencies = [
+  "flask==2.0.1"
+]
+"""
+        )
+
+    monkeypatch.setenv("UV_FROZEN", "0")
+    monkeypatch.setattr(pyproject, "VirtualEnv", MockVirtualEnv)
+
+    source = pyproject.PyProjectSource(filename, locked=True)
+    assert list(source.collect()) == []
+    assert os.environ["UV_FROZEN"] == "0"
 
 
 @pytest.mark.online

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,6 +11,7 @@ from pip_audit._cli import (
     VulnerabilityDescriptionChoice,
     VulnerabilityServiceChoice,
 )
+from pip_audit._state import AuditState
 
 
 class TestOutputFormatChoice:
@@ -70,6 +71,24 @@ class TestProgressSpinnerChoice:
     def test_str(self):
         for choice in ProgressSpinnerChoice:
             assert str(choice) == choice.value
+
+
+def test_dep_source_from_locked_uv_project(tmp_path):
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text("[project]\ndependencies = []\n")
+    (tmp_path / "uv.lock").write_text("")
+
+    source = pip_audit._cli._dep_source_from_project_path(
+        tmp_path,
+        index_url="https://example.com/simple",
+        extra_index_urls=["https://extra.example.com/simple"],
+        locked=True,
+        state=AuditState(),
+    )
+
+    assert isinstance(source, pip_audit._cli.PyProjectSource)
+    assert source.filename == pyproject_path
+    assert source.locked
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1077.

This updates `--locked` project-path handling to recognize `uv.lock` when no `pylock` files are present. For uv projects, dependency collection now runs with `UV_FROZEN=1` so uv does not update `uv.lock` during audit resolution.

Validation:
- `make test T=test/test_cli.py`
- `make test T=test/dependency_source/test_pyproject.py`
- `make lint`