### PR TITLE
fix: preserve comment indentation when rewriting requirements files

### DIFF
--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -17,6 +17,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 from pip_requirements_parser import (
+    CommentRequirementLine,
     InstallRequirement,
     InvalidRequirementLine,
     RequirementsFile,
@@ -221,6 +222,7 @@ class RequirementSource(DependencySource):
         # This time we're using the `RequirementsFile.parse` API instead of `Requirements.from_file`
         # since we want to access each line sequentially in order to rewrite the file.
         reqs = list(RequirementsFile.parse(filename=filename.as_posix()))
+        original_lines = filename.read_text().splitlines()
 
         # Check ahead of time for anything invalid in the requirements file since we don't want to
         # encounter this while writing out the file. Check for duplicate requirements and lines that
@@ -260,7 +262,20 @@ class RequirementSource(DependencySource):
                         fix_version.dep.version
                     ) and not req.specifier.contains(fix_version.version):
                         req.req.specifier = SpecifierSet(f"=={fix_version.version}")
-                print(req.dumps(), file=f)
+                line = req.dumps()
+                if isinstance(req, CommentRequirementLine):
+                    # `pip-requirements-parser` unconditionally strips comment-only
+                    # lines, discarding the indentation that tools like
+                    # `pip-compile` use to mark a "# via ..." backreference comment
+                    # as belonging to the preceding requirement. Recover the
+                    # original indentation from the source file when the physical
+                    # line consists solely of that comment.
+                    original_line = original_lines[req.line_number - 1]
+                    if original_line.lstrip().startswith("#") and (
+                        original_line.strip() == line
+                    ):
+                        line = original_line
+                print(line, file=f)
 
             # The vulnerable dependency may not be explicitly listed in the requirements file if it
             # is a subdependency of a requirement. In this case, we should explicitly add the fixed

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -330,6 +330,23 @@ def test_requirement_source_fix_comments(req_file):
     )
 
 
+def test_requirement_source_fix_comments_preserve_indent(req_file):
+    # Regression test for the `pip-compile`-style "# via ..." backreference comment: it's a
+    # comment-only physical line indented by 4 spaces to signal that it belongs to the preceding
+    # requirement, and that indentation should survive a fix.
+    _check_fixes(
+        ["flask==0.5\n    # via -r requirements.in\nrequests==2.0"],
+        ["flask==1.0\n    # via -r requirements.in\nrequests==2.0"],
+        [req_file()],
+        [
+            ResolvedFixVersion(
+                dep=ResolvedDependency(name="flask", version=Version("0.5")),
+                version=Version("1.0"),
+            )
+        ],
+    )
+
+
 def test_requirement_source_fix_parse_failure(monkeypatch, req_file):
     logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(requirement, "logger", logger)
@@ -728,13 +745,11 @@ def test_requirement_source_fix_explicit_subdep_comment_retention(req_file):
     # Now place a fix for the top-level `flask` requirement after the `jinja2` subdependency fix.
     #
     # When applying the `flask` fix, `pip-audit` reparses the requirements file, and writes it back
-    # out with the fixed `flask` version with the comments preserved.
-    #
-    # One quirk is that comment indentation isn't preserved (the automated comment was originally
-    # indented with 4 spaces).
+    # out with the fixed `flask` version with the comments preserved, including the original
+    # indentation of the automated comment (it was originally indented with 4 spaces).
     _check_fixes(
         ["flask==2.0.1"],
-        ["flask==3.0.0\n# pip-audit: subdependency explicitly fixed\njinja2==4.0.0"],
+        ["flask==3.0.0\n    # pip-audit: subdependency explicitly fixed\njinja2==4.0.0"],
         [req_file()],
         [
             ResolvedFixVersion(


### PR DESCRIPTION
## Summary

`--fix` strips the indentation of comment-only lines (e.g. the `pip-compile`-style `    # via ...` backreference comment) when rewriting a requirements file, even though it correctly preserves everything else. The root cause is that `pip-requirements-parser`'s comment parsing unconditionally `.strip()`s comment-only lines, discarding the leading whitespace that `pip-compile` uses to signal that a comment belongs to the preceding requirement rather than being a standalone comment.

Since that stripping happens inside the third-party parser before `pip-audit` ever sees the line, this fix recovers the original indentation from the source file at write time: for any parsed comment-only line, if the corresponding physical line in the original file is (once stripped) identical to the parsed comment, the original raw line (including its indentation) is written back instead of the parser's stripped version.

## Changes

- `pip_audit/_dependency_source/requirement.py`: in `RequirementSource._fix_file`, read the original file's lines once, and for each `CommentRequirementLine` restore the original line (with its indentation) when the physical line consists solely of that comment.
- `test/dependency_source/test_requirement.py`: add `test_requirement_source_fix_comments_preserve_indent` covering the `pip-compile`-style indented `# via ...` comment from the issue, and update `test_requirement_source_fix_explicit_subdep_comment_retention`'s expected output/docstring — this test previously codified the buggy unindented behavior as expected, and now asserts the corrected indentation instead.

Fixes #566