### PR TITLE
feat(cli): add --cyclonedx-xml and --cyclonedx-json flags

### DIFF
--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -391,6 +391,24 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         "this can only be used with hashed requirements files or if the `--no-deps` flag has been "
         "provided",
     )
+    parser.add_argument(
+        "--cyclonedx-xml",
+        type=Path,
+        metavar="FILE",
+        dest="cyclonedx_xml",
+        default=None,
+        help="write a CycloneDX SBOM report in XML format to the given file, "
+        "in addition to the main output",
+    )
+    parser.add_argument(
+        "--cyclonedx-json",
+        type=Path,
+        metavar="FILE",
+        dest="cyclonedx_json",
+        default=None,
+        help="write a CycloneDX SBOM report in JSON format to the given file, "
+        "in addition to the main output",
+    )
     return parser
 
 
@@ -406,6 +424,35 @@ def _parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:  # pragm
     logger.debug(f"parsed arguments: {args}")
 
     return args
+
+
+def _write_cyclonedx_reports(
+    args: argparse.Namespace,
+    result: dict[Dependency, list[VulnerabilityResult]],
+    fixes: list,
+) -> None:
+    """
+    Write CycloneDX SBOM reports to files if ``--cyclonedx-xml`` or
+    ``--cyclonedx-json`` were supplied.
+    """
+    if args.cyclonedx_xml is None and args.cyclonedx_json is None:
+        return
+
+    from pip_audit._format import CycloneDxFormat
+
+    if args.cyclonedx_xml is not None:
+        fmt = CycloneDxFormat(inner_format=CycloneDxFormat.InnerFormat.Xml)
+        report = fmt.format(result, fixes)
+        with args.cyclonedx_xml.open("w") as f:
+            f.write(report)
+        logger.info(f"Wrote CycloneDX XML report to {args.cyclonedx_xml}")
+
+    if args.cyclonedx_json is not None:
+        fmt = CycloneDxFormat(inner_format=CycloneDxFormat.InnerFormat.Json)
+        report = fmt.format(result, fixes)
+        with args.cyclonedx_json.open("w") as f:
+            f.write(report)
+        logger.info(f"Wrote CycloneDX JSON report to {args.cyclonedx_json}")
 
 
 def _dep_source_from_project_path(
@@ -612,6 +659,8 @@ def audit() -> None:  # pragma: no cover
                         logger.debug(skip_reason)
                         fix = SkippedFixVersion(fix.dep, skip_reason)
                 fixes.append(fix)
+
+    _write_cyclonedx_reports(args, result, fixes)
 
     if vuln_count > 0:
         if vuln_ignore_count:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -232,3 +232,93 @@ def test_environment_variable(monkeypatch):
     assert args.output == Path("/tmp/fake")
     assert not args.progress_spinner
     assert args.vulnerability_service == VulnerabilityServiceChoice.Osv
+
+
+class TestCycloneDxExtraOutput:
+    """Tests for --cyclonedx-xml and --cyclonedx-json flags."""
+
+    def test_cyclonedx_xml_default_is_none(self):
+        parser = pip_audit._cli._parser()
+        args = parser.parse_args([])
+        assert args.cyclonedx_xml is None
+
+    def test_cyclonedx_json_default_is_none(self):
+        parser = pip_audit._cli._parser()
+        args = parser.parse_args([])
+        assert args.cyclonedx_json is None
+
+    def test_cyclonedx_xml_arg_parsed(self, tmp_path):
+        xml_file = tmp_path / "report.xml"
+        parser = pip_audit._cli._parser()
+        args = parser.parse_args(["--cyclonedx-xml", str(xml_file)])
+        assert args.cyclonedx_xml == xml_file
+
+    def test_cyclonedx_json_arg_parsed(self, tmp_path):
+        json_file = tmp_path / "report.json"
+        parser = pip_audit._cli._parser()
+        args = parser.parse_args(["--cyclonedx-json", str(json_file)])
+        assert args.cyclonedx_json == json_file
+
+    def test_cyclonedx_both_flags_together(self, tmp_path):
+        xml_file = tmp_path / "report.xml"
+        json_file = tmp_path / "report.json"
+        parser = pip_audit._cli._parser()
+        args = parser.parse_args(
+            ["--cyclonedx-xml", str(xml_file), "--cyclonedx-json", str(json_file)]
+        )
+        assert args.cyclonedx_xml == xml_file
+        assert args.cyclonedx_json == json_file
+
+    def test_write_cyclonedx_reports_xml(self, tmp_path, monkeypatch):
+        xml_file = tmp_path / "report.xml"
+        result = {
+            pretend.stub(
+                is_skipped=lambda: False,
+                name="test-pkg",
+                canonical_name="test-pkg",
+                version=1,
+            ): [
+                pretend.stub(
+                    fix_versions=[2],
+                    id="CVE-2024-0001",
+                    aliases=set(),
+                    has_any_id=lambda x: False,
+                    description="test vuln",
+                )
+            ]
+        }
+        args = pretend.stub(cyclonedx_xml=xml_file, cyclonedx_json=None)
+        pip_audit._cli._write_cyclonedx_reports(args, result, [])
+        assert xml_file.exists()
+        content = xml_file.read_text()
+        assert "test-pkg" in content
+
+    def test_write_cyclonedx_reports_json(self, tmp_path, monkeypatch):
+        json_file = tmp_path / "report.json"
+        result = {
+            pretend.stub(
+                is_skipped=lambda: False,
+                name="test-pkg",
+                canonical_name="test-pkg",
+                version=1,
+            ): [
+                pretend.stub(
+                    fix_versions=[2],
+                    id="CVE-2024-0001",
+                    aliases=set(),
+                    has_any_id=lambda x: False,
+                    description="test vuln",
+                )
+            ]
+        }
+        args = pretend.stub(cyclonedx_xml=None, cyclonedx_json=json_file)
+        pip_audit._cli._write_cyclonedx_reports(args, result, [])
+        assert json_file.exists()
+        content = json_file.read_text()
+        assert "test-pkg" in content
+
+    def test_write_cyclonedx_reports_none_when_no_flags(self, tmp_path):
+        args = pretend.stub(cyclonedx_xml=None, cyclonedx_json=None)
+        result = {}
+        # Should not raise or write any files
+        pip_audit._cli._write_cyclonedx_reports(args, result, [])


### PR DESCRIPTION
## Summary

Closes #753

Adds two new CLI flags that write CycloneDX SBOM reports to files **in addition** to the main output format. This allows users to get console output in one format (e.g. columns) while simultaneously saving CycloneDX reports for CI/CD integration.

## New flags

- `--cyclonedx-xml FILE`: writes CycloneDX XML SBOM to the given file
- `--cyclonedx-json FILE`: writes CycloneDX JSON SBOM to the given file

Both flags can be used together and alongside any `--format` choice.

## Example usage

```bash
# Console output in columns, plus CycloneDX JSON report for CI
pip-audit --format columns --cyclonedx-json sbom.json

# Console output in markdown, plus both XML and JSON reports
pip-audit --format markdown --cyclonedx-xml sbom.xml --cyclonedx-json sbom.json

# Save main output to file AND get CycloneDX reports
pip-audit -f json -o results.json --cyclonedx-xml sbom.xml
```

## Changes

- **`pip_audit/_cli.py`**: Added `--cyclonedx-xml` and `--cyclonedx-json` argument definitions, and `_write_cyclonedx_reports()` helper function
- **`test/test_cli.py`**: Added 8 tests covering argument parsing, file writing for both formats, combined usage, and no-op when flags are absent

## Test plan

- `pytest test/test_cli.py` — 35/35 passing (8 new + 27 existing)
- `pytest test/format/` — 36/36 passing (no regressions)
- All tests run on Python 3.14