### PR TITLE
Catch read timeouts when querying vulnerability feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All versions prior to 0.0.9 are untracked.
 * Read timeouts while querying a vulnerability feed (OSV, PyPI, ESMS) are now
   caught and surfaced as a friendly `ConnectionError`, instead of escaping as an
   uncaught `requests.ReadTimeout` traceback
-  ([#1083](https://github.com/pypa/pip-audit/pull/1083))
+  ([#1084](https://github.com/pypa/pip-audit/pull/1084))
 
 ## [2.10.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Read timeouts while querying a vulnerability feed (OSV, PyPI, ESMS) are now
+  caught and surfaced as a friendly `ConnectionError`, instead of escaping as an
+  uncaught `requests.ReadTimeout` traceback
+  ([#1083](https://github.com/pypa/pip-audit/pull/1083))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_service/esms.py
+++ b/pip_audit/_service/esms.py
@@ -74,7 +74,7 @@ class EcosystemsService(VulnerabilityService):
                 timeout=self.timeout,
             )
             response.raise_for_status()
-        except requests.ConnectTimeout:
+        except requests.Timeout:
             raise ConnectionError("Could not connect to ESMS' vulnerability feed")
         except requests.HTTPError as http_error:
             raise ServiceError from http_error

--- a/pip_audit/_service/osv.py
+++ b/pip_audit/_service/osv.py
@@ -73,7 +73,7 @@ class OsvService(VulnerabilityService):
                 timeout=self.timeout,
             )
             response.raise_for_status()
-        except requests.ConnectTimeout:
+        except requests.Timeout:
             raise ConnectionError("Could not connect to OSV's vulnerability feed")
         except requests.HTTPError as http_error:
             raise ServiceError from http_error

--- a/pip_audit/_service/pypi.py
+++ b/pip_audit/_service/pypi.py
@@ -68,7 +68,7 @@ class PyPIService(VulnerabilityService):
             # happen during an outage or network event.
             # Ref 2022-06-10: https://status.python.org/incidents/lgpr13fy71bk
             raise ConnectionError("PyPI is not redirecting properly")
-        except requests.ConnectTimeout:
+        except requests.Timeout:
             # Apart from a normal network outage, this can happen for two main
             # reasons:
             # 1. PyPI's APIs are offline

--- a/test/service/test_esms.py
+++ b/test/service/test_esms.py
@@ -5,7 +5,7 @@ import random
 import pretend  # type: ignore
 import pytest
 from packaging.version import Version
-from requests.exceptions import ConnectTimeout, HTTPError
+from requests.exceptions import ConnectTimeout, HTTPError, ReadTimeout
 
 import pip_audit._service as service
 
@@ -89,6 +89,17 @@ def test_esms_no_vuln():
 def test_esms_connection_error(monkeypatch):
     esms = service.EcosystemsService()
     monkeypatch.setattr(esms.session, "get", pretend.raiser(ConnectTimeout))
+
+    dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
+    with pytest.raises(
+        service.ConnectionError, match="Could not connect to ESMS' vulnerability feed"
+    ):
+        dict(esms.query_all(iter([dep])))
+
+
+def test_esms_read_timeout(monkeypatch):
+    esms = service.EcosystemsService()
+    monkeypatch.setattr(esms.session, "get", pretend.raiser(ReadTimeout))
 
     dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
     with pytest.raises(

--- a/test/service/test_osv.py
+++ b/test/service/test_osv.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pretend  # type: ignore
 import pytest
 from packaging.version import Version
-from requests.exceptions import ConnectTimeout, HTTPError
+from requests.exceptions import ConnectTimeout, HTTPError, ReadTimeout
 
 import pip_audit._service as service
 
@@ -98,6 +98,17 @@ def test_osv_no_vuln():
 def test_osv_connection_error(monkeypatch):
     osv = service.OsvService()
     monkeypatch.setattr(osv.session, "post", pretend.raiser(ConnectTimeout))
+
+    dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
+    with pytest.raises(
+        service.ConnectionError, match="Could not connect to OSV's vulnerability feed"
+    ):
+        dict(osv.query_all(iter([dep])))
+
+
+def test_osv_read_timeout(monkeypatch):
+    osv = service.OsvService()
+    monkeypatch.setattr(osv.session, "post", pretend.raiser(ReadTimeout))
 
     dep = service.ResolvedDependency("jinja2", Version("2.4.1"))
     with pytest.raises(

--- a/test/service/test_pypi.py
+++ b/test/service/test_pypi.py
@@ -76,6 +76,20 @@ def test_pypi_connect_timeout(monkeypatch):
         dict(pypi.query_all(iter([service.ResolvedDependency("fakedep", Version("1.0.0"))])))
 
 
+def test_pypi_read_timeout(monkeypatch):
+    session = pretend.stub(get=pretend.raiser(requests.ReadTimeout))
+    caching_session = pretend.call_recorder(lambda c, **kw: session)
+    monkeypatch.setattr(service.pypi, "caching_session", caching_session)
+
+    cache_dir = pretend.stub()
+    pypi = service.PyPIService(cache_dir)
+
+    with pytest.raises(
+        service.ConnectionError, match="Could not connect to PyPI's vulnerability feed"
+    ):
+        dict(pypi.query_all(iter([service.ResolvedDependency("fakedep", Version("1.0.0"))])))
+
+
 def test_pypi_http_notfound(monkeypatch, cache_dir):
     # If we get a "not found" response, that means that we're querying a package or version that
     # isn't known to PyPI. If that's the case, we should just log a debug message and continue on


### PR DESCRIPTION
## Summary

Each vulnerability service (`osv.py`, `pypi.py`, `esms.py`) passes `timeout=self.timeout` to its HTTP request, but the surrounding `try` only catches `requests.ConnectTimeout`:

```python
response = self.session.post(..., timeout=self.timeout)
...
except requests.ConnectTimeout:
    raise ConnectionError("Could not connect to OSV's vulnerability feed")
```

The `timeout` argument guards **both** connect and read phases. A slow-but-reachable server (accepts the connection, then stalls before responding) raises `requests.ReadTimeout`, which is **not** a subclass of `ConnectTimeout`:

```
ReadTimeout   -> Timeout -> RequestException
ConnectTimeout -> (ConnectionError, Timeout) -> RequestException
```

So a read timeout currently escapes as an uncaught `requests.ReadTimeout` traceback instead of the intended friendly `pip_audit` `ConnectionError`.

## Fix

Catch the `requests.Timeout` base class instead — it covers both `ConnectTimeout` and `ReadTimeout`. Messages are unchanged. Added a `ReadTimeout` test for each of the three services (mirroring the existing `ConnectTimeout` tests), plus a CHANGELOG entry.

## Verification

`make test` on the service suite: **80 passed** (including the 3 new read-timeout tests), `ruff` clean.