### PR TITLE
Add optional CycloneDX output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* Added `--cyclonedx FILE` to write a CycloneDX JSON or XML report while retaining
+  the selected primary output format ([#753](https://github.com/pypa/pip-audit/issues/753)).
+
 ## [2.10.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ options:
                         False)
   -o FILE, --output FILE
                         output results to the given file (default: stdout)
+  --cyclonedx FILE      write a CycloneDX SBOM to FILE; infer JSON or XML
+                        from its extension (default: None)
   --ignore-vuln ID      ignore a specific vulnerability by its vulnerability
                         ID; this option can be used multiple times (default:
                         [])

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -67,6 +67,26 @@ def _output_io(name: Path) -> Iterator[IO[str]]:  # pragma: no cover
             yield io
 
 
+def _cyclonedx_format(output: Path) -> CycloneDxFormat:
+    """Return the CycloneDX formatter implied by an output filename."""
+    suffix = output.suffix.lower()
+    if suffix == ".json":
+        return CycloneDxFormat(inner_format=CycloneDxFormat.InnerFormat.Json)
+    if suffix == ".xml":
+        return CycloneDxFormat(inner_format=CycloneDxFormat.InnerFormat.Xml)
+    raise ValueError(f"unsupported CycloneDX output extension: {output.suffix}")
+
+
+def _cyclonedx_output_path(value: str) -> Path:
+    """Validate a CycloneDX output path supplied on the command line."""
+    output = Path(value)
+    if output.suffix.lower() not in {".json", ".xml"}:
+        raise argparse.ArgumentTypeError(
+            "CycloneDX output must have a .json or .xml filename extension"
+        )
+    return output
+
+
 @enum.unique
 class OutputFormatChoice(str, enum.Enum):
     """
@@ -373,6 +393,12 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         default=os.environ.get("PIP_AUDIT_OUTPUT", "stdout"),
     )
     parser.add_argument(
+        "--cyclonedx",
+        type=_cyclonedx_output_path,
+        metavar="FILE",
+        help="write a CycloneDX SBOM to FILE; infer JSON or XML from its extension",
+    )
+    parser.add_argument(
         "--ignore-vuln",
         type=str,
         metavar="ID",
@@ -458,6 +484,7 @@ def audit() -> None:  # pragma: no cover
     output_desc = args.desc.to_bool(args.format)
     output_aliases = args.aliases.to_bool(args.format)
     formatter = args.format.to_format(output_desc, output_aliases)
+    cyclonedx_formatter = _cyclonedx_format(args.cyclonedx) if args.cyclonedx else None
 
     # Check for flags that are only valid with project paths
     if args.project_path is None:
@@ -612,6 +639,10 @@ def audit() -> None:  # pragma: no cover
                         logger.debug(skip_reason)
                         fix = SkippedFixVersion(fix.dep, skip_reason)
                 fixes.append(fix)
+
+    if cyclonedx_formatter:
+        with _output_io(args.cyclonedx) as io:
+            print(cyclonedx_formatter.format(result, fixes), file=io)
 
     if vuln_count > 0:
         if vuln_ignore_count:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,6 +11,7 @@ from pip_audit._cli import (
     VulnerabilityDescriptionChoice,
     VulnerabilityServiceChoice,
 )
+from pip_audit._format import CycloneDxFormat
 
 
 class TestOutputFormatChoice:
@@ -24,6 +25,28 @@ class TestOutputFormatChoice:
     def test_str(self):
         for choice in OutputFormatChoice:
             assert str(choice) == choice.value
+
+
+@pytest.mark.parametrize(
+    ("filename", "inner_format"),
+    [
+        ("report.json", CycloneDxFormat.InnerFormat.Json),
+        ("report.xml", CycloneDxFormat.InnerFormat.Xml),
+        ("report.JSON", CycloneDxFormat.InnerFormat.Json),
+    ],
+)
+def test_cyclonedx_format(filename, inner_format):
+    formatter = pip_audit._cli._cyclonedx_format(Path(filename))
+
+    assert formatter._inner_format is inner_format
+
+
+@pytest.mark.parametrize("filename", ["report", "report.csv"])
+def test_cyclonedx_output_path_requires_supported_extension(filename):
+    parser = pip_audit._cli._parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--cyclonedx", filename])
 
 
 class TestVulnerabilityServiceChoice:
@@ -140,19 +163,22 @@ def test_plurals(capsys, monkeypatch, args, vuln_count, pkg_count, expected):
 
 
 @pytest.mark.parametrize(
-    "vuln_count, pkg_count, skip_count, print_format",
+    "vuln_count, pkg_count, skip_count, print_format, cyclonedx",
     [
-        (1, 1, 0, True),
-        (2, 1, 0, True),
-        (2, 2, 0, True),
-        (0, 0, 0, False),
-        (0, 1, 0, False),
+        (1, 1, 0, True, False),
+        (2, 1, 0, True, False),
+        (2, 2, 0, True, False),
+        (0, 0, 0, False, False),
+        (0, 1, 0, False, False),
         # If there are no vulnerabilities but a dependency has been skipped, we
         # should print the formatted result
-        (0, 0, 1, True),
+        (0, 0, 1, True, False),
+        (0, 1, 0, False, True),
     ],
 )
-def test_print_format(monkeypatch, vuln_count, pkg_count, skip_count, print_format):
+def test_print_format(
+    monkeypatch, tmp_path, vuln_count, pkg_count, skip_count, print_format, cyclonedx
+):
     dummysource = pretend.stub(fix=lambda a: None)
     monkeypatch.setattr(pip_audit._cli, "PipSource", lambda *a, **kw: dummysource)
 
@@ -161,9 +187,16 @@ def test_print_format(monkeypatch, vuln_count, pkg_count, skip_count, print_form
         is_manifest=False,
     )
     monkeypatch.setattr(pip_audit._cli, "ColumnsFormat", lambda *a, **kw: dummyformat)
+    cyclonedx_format = pretend.stub(format=pretend.call_recorder(lambda _result, _fixes: "SBOM"))
+    monkeypatch.setattr(
+        pip_audit._cli,
+        "_cyclonedx_format",
+        lambda _output: cyclonedx_format,
+    )
 
     parser = pip_audit._cli._parser()
-    monkeypatch.setattr(pip_audit._cli, "_parse_args", lambda *a: parser.parse_args([]))
+    args = ["--cyclonedx", str(tmp_path / "audit.json")] if cyclonedx else []
+    monkeypatch.setattr(pip_audit._cli, "_parse_args", lambda *a: parser.parse_args(args))
 
     result = [
         (
@@ -213,6 +246,9 @@ def test_print_format(monkeypatch, vuln_count, pkg_count, skip_count, print_form
         pass
 
     assert bool(dummyformat.format.calls) == print_format
+    assert bool(cyclonedx_format.format.calls) == cyclonedx
+    if cyclonedx:
+        assert (tmp_path / "audit.json").read_text() == "SBOM\n"
 
 
 def test_environment_variable(monkeypatch):


### PR DESCRIPTION
Closes #753

## Summary

- Add --cyclonedx FILE to write a CycloneDX JSON or XML SBOM alongside the selected primary output.
- Validate .json and .xml output filenames.
- Write the SBOM even when the audit finds no vulnerabilities.

## Testing

- python -m pytest test/test_cli.py (33 passed)

A full Windows suite run completed with 239 passed and 1 skipped. Its five failures are unrelated platform/resolver cases, including the Unix-only false executable test.