### PR TITLE
fix: read and write pip's http-v2 cache (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* `pip-audit` now shares `pip`'s `http-v2` HTTP cache format (`pip` >= 23.3) when
+  reusing `pip`'s cache directory, instead of only reading and writing the older,
+  now-frozen `http` format. Sharing with older `pip` installations, which never
+  write to `http-v2`, still uses the legacy format
+  ([#794](https://github.com/pypa/pip-audit/issues/794))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_cache.py
+++ b/pip_audit/_cache.py
@@ -9,14 +9,16 @@ import os
 import shutil
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any
+from typing import IO, Any
 
 import pip_api
 import requests
 from cachecontrol import CacheControl
-from cachecontrol.caches import FileCache
+from cachecontrol.cache import SeparateBodyBaseCache
+from cachecontrol.caches import FileCache, SeparateBodyFileCache
 from packaging.version import Version
 from platformdirs import user_cache_path
 
@@ -28,12 +30,57 @@ logger = logging.getLogger(__name__)
 # to discover the `pip` HTTP cache
 _MINIMUM_PIP_VERSION = Version("20.1")
 
+# `pip` 23.3 (https://github.com/pypa/pip/pull/11143) switched its HTTP cache from a
+# single combined (header + body) file per entry, stored under an `http` directory, to
+# `http-v2`: a format that stores each entry's response body separately from its
+# metadata. `pip` never writes to `http` once it's past this version, so we need to
+# know which format the installed `pip` actually uses in order to keep sharing a warm,
+# readable cache with it. See `_SafeFileCache` and `_LegacySafeFileCache`.
+_MINIMUM_PIP_HTTP_V2_VERSION = Version("23.3")
+
 _PIP_VERSION = Version(str(pip_api.PIP_VERSION))
 
 _PIP_AUDIT_LEGACY_INTERNAL_CACHE = Path.home() / ".pip-audit-cache"
 
+# Matches `cachecontrol.caches.file_cache._FileCacheMixin`'s default `dirmode`.
+_CACHE_DIR_MODE = 0o0700
 
-def _get_pip_cache() -> Path:
+
+def _atomic_write(path: str, value: bytes) -> None:
+    """
+    Write `value` to `path`, creating parent directories as needed.
+
+    We don't want to use lock files since `pip` isn't going to recognise those. We should
+    write to the cache in a similar way to how `pip` does it. We create a temporary file,
+    then atomically replace the actual cache key's filename with it. This ensures
+    that other concurrent `pip` or `pip-audit` instances don't read partial data.
+    """
+
+    # Make sure the directory exists
+    try:
+        os.makedirs(os.path.dirname(path), _CACHE_DIR_MODE)
+    except OSError:  # pragma: no cover
+        pass
+
+    with NamedTemporaryFile(delete=False, dir=os.path.dirname(path)) as io:
+        io.write(value)
+
+        # NOTE(ww): Similar to what `pip` does in `adjacent_tmp_file`.
+        io.flush()
+        os.fsync(io.fileno())
+
+    # NOTE(ww): Windows won't let us rename the temporary file until it's closed,
+    # which is why we call `os.replace()` here rather than in the `with` block above.
+    os.replace(io.name, path)
+
+
+def _get_pip_cache() -> tuple[Path, bool]:
+    """
+    Returns `pip`'s HTTP cache directory, and whether that directory uses `pip`'s
+    legacy (pre-23.3) single-file cache format rather than the current `http-v2`
+    format (see `_MINIMUM_PIP_HTTP_V2_VERSION`).
+    """
+
     # Unless the cache directory is specifically set by the `--cache-dir` option, we try to share
     # the `pip` HTTP cache
     cmd = [sys.executable, "-m", "pip", "cache", "dir"]
@@ -43,14 +90,18 @@ def _get_pip_cache() -> Path:
         # NOTE: This should only happen if pip's cache has been explicitly disabled,
         # which we check for in the caller (via `PIP_NO_CACHE_DIR`).
         raise ServiceError(f"Failed to query the `pip` HTTP cache directory: {cmd}") from cpe
-    cache_dir = process.stdout.decode("utf-8").strip("\n")
-    http_cache_dir = Path(cache_dir) / "http"
-    return http_cache_dir
+    cache_dir = Path(process.stdout.decode("utf-8").strip("\n"))
+
+    if _PIP_VERSION >= _MINIMUM_PIP_HTTP_V2_VERSION:
+        return cache_dir / "http-v2", False
+    return cache_dir / "http", True
 
 
-def _get_cache_dir(custom_cache_dir: Path | None, *, use_pip: bool = True) -> Path:
+def _get_cache_dir(custom_cache_dir: Path | None, *, use_pip: bool = True) -> tuple[Path, bool]:
     """
-    Returns a directory path suitable for HTTP caching.
+    Returns a directory path suitable for HTTP caching, and whether that directory
+    uses `pip`'s legacy (pre-23.3) single-file cache format rather than the current
+    `http-v2` format (see `_MINIMUM_PIP_HTTP_V2_VERSION`).
 
     The directory is **not** guaranteed to exist.
 
@@ -58,9 +109,11 @@ def _get_cache_dir(custom_cache_dir: Path | None, *, use_pip: bool = True) -> Pa
     **unless** `PIP_NO_CACHE_DIR` is present in the environment.
     """
 
-    # If the user has explicitly requested a directory, pass it through unscathed.
+    # If the user has explicitly requested a directory, pass it through unscathed. It isn't
+    # shared with any particular `pip` version, so we always use the current cache format
+    # for it.
     if custom_cache_dir is not None:
-        return custom_cache_dir
+        return custom_cache_dir, False
 
     # Retrieve pip-audit's default internal cache using `platformdirs`.
     pip_audit_cache_dir = user_cache_path("pip-audit", appauthor=False, ensure_exists=True)
@@ -74,24 +127,117 @@ def _get_cache_dir(custom_cache_dir: Path | None, *, use_pip: bool = True) -> Pa
 
     # Respect pip's PIP_NO_CACHE_DIR environment setting.
     if use_pip and not os.getenv("PIP_NO_CACHE_DIR"):
-        pip_cache_dir = _get_pip_cache() if _PIP_VERSION >= _MINIMUM_PIP_VERSION else None
-        if pip_cache_dir is not None:
-            return pip_cache_dir
+        if _PIP_VERSION >= _MINIMUM_PIP_VERSION:
+            return _get_pip_cache()
         else:
             logger.warning(
                 f"pip {_PIP_VERSION} doesn't support the `cache dir` subcommand, "
                 f"using {pip_audit_cache_dir} instead"
             )
-            return pip_audit_cache_dir
+            return pip_audit_cache_dir, False
     else:
-        return pip_audit_cache_dir
+        return pip_audit_cache_dir, False
 
 
-class _SafeFileCache(FileCache):
+class _SafeFileCache(SeparateBodyBaseCache):
     """
-    A rough mirror of `pip`'s `SafeFileCache` that *should* be runtime-compatible
+    A rough mirror of `pip`'s current `SafeFileCache` that *should* be runtime-compatible
     with `pip` (i.e., does not interfere with `pip` when it shares the same
     caching directory as a running `pip` process).
+
+    `pip` 23.3 (https://github.com/pypa/pip/pull/11143) moved to storing each cache
+    entry's response body separately from its metadata (in an adjacent `.body` file),
+    reducing peak memory usage. This is `pip`'s `http-v2` cache format; see
+    `_LegacySafeFileCache` for the format used by `pip` versions older than 23.3.
+    """
+
+    def __init__(self, directory: Path):
+        self._logged_warning = False
+        self._directory = str(directory)
+
+    def _get_cache_path(self, key: str) -> str:
+        # From `cachecontrol.caches.file_cache.SeparateBodyFileCache.encode`/`_fn`,
+        # brought into our class for backwards-compatibility and to avoid using a
+        # non-public method. This mirrors `pip`'s own `SafeFileCache._get_cache_path`.
+        hashed = SeparateBodyFileCache.encode(key)
+        parts = list(hashed[:5]) + [hashed]
+        return os.path.join(self._directory, *parts)
+
+    def _warn_once(self, message: str) -> None:
+        if not self._logged_warning:
+            logger.warning(message)
+            self._logged_warning = True
+
+    def get(self, key: str) -> bytes | None:
+        # The cache entry is only valid if both the metadata and the body are present,
+        # mirroring `pip`'s own `SafeFileCache.get`. This also means that an entry
+        # written by `_LegacySafeFileCache` (which never writes a `.body` file) is
+        # always treated as a miss here, rather than misread as `http-v2` metadata.
+        metadata_path = self._get_cache_path(key)
+        body_path = metadata_path + ".body"
+        if not (os.path.exists(metadata_path) and os.path.exists(body_path)):
+            return None
+
+        try:
+            with open(metadata_path, "rb") as f:
+                return f.read()
+        except Exception as e:  # pragma: no cover
+            self._warn_once(
+                f"Failed to read from cache directory, performance may be degraded: {e}"
+            )
+            return None
+
+    def get_body(self, key: str) -> IO[bytes] | None:
+        metadata_path = self._get_cache_path(key)
+        body_path = metadata_path + ".body"
+        if not (os.path.exists(metadata_path) and os.path.exists(body_path)):
+            return None
+
+        try:
+            return open(body_path, "rb")
+        except Exception as e:  # pragma: no cover
+            self._warn_once(
+                f"Failed to read from cache directory, performance may be degraded: {e}"
+            )
+            return None
+
+    def set(self, key: str, value: bytes, expires: int | datetime | None = None) -> None:
+        try:
+            _atomic_write(self._get_cache_path(key), value)
+        except Exception as e:  # pragma: no cover
+            self._warn_once(f"Failed to write to cache directory, performance may be degraded: {e}")
+
+    def set_body(self, key: str, body: bytes) -> None:
+        try:
+            _atomic_write(self._get_cache_path(key) + ".body", body)
+        except Exception as e:  # pragma: no cover
+            self._warn_once(f"Failed to write to cache directory, performance may be degraded: {e}")
+
+    def _remove(self, path: str) -> None:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+    def delete(self, key: str) -> None:  # pragma: no cover
+        try:
+            metadata_path = self._get_cache_path(key)
+            self._remove(metadata_path)
+            self._remove(metadata_path + ".body")
+        except Exception as e:
+            self._warn_once(
+                f"Failed to delete file from cache directory, performance may be degraded: {e}"
+            )
+
+
+class _LegacySafeFileCache(FileCache):
+    """
+    A rough mirror of `pip`'s pre-23.3 `SafeFileCache`, which stores each cache entry
+    as a single combined (header + body) file. `pip` 23.3
+    (https://github.com/pypa/pip/pull/11143) replaced this format with `http-v2` (see
+    `_SafeFileCache`); we keep this implementation around so that we can still share a
+    warm cache with installations of `pip` older than 23.3, which never write to
+    `http-v2`.
     """
 
     def __init__(self, directory: Path):
@@ -111,37 +257,13 @@ class _SafeFileCache(FileCache):
 
     def set(self, key: str, value: bytes, expires: Any | None = None) -> None:
         try:
-            self._set_impl(key, value)
+            _atomic_write(super()._fn(key), value)
         except Exception as e:  # pragma: no cover
             if not self._logged_warning:
                 logger.warning(
                     f"Failed to write to cache directory, performance may be degraded: {e}"
                 )
                 self._logged_warning = True
-
-    def _set_impl(self, key: str, value: bytes) -> None:
-        name: str = super()._fn(key)
-
-        # Make sure the directory exists
-        try:
-            os.makedirs(os.path.dirname(name), self.dirmode)
-        except OSError:  # pragma: no cover
-            pass
-
-        # We don't want to use lock files since `pip` isn't going to recognise those. We should
-        # write to the cache in a similar way to how `pip` does it. We create a temporary file,
-        # then atomically replace the actual cache key's filename with it. This ensures
-        # that other concurrent `pip` or `pip-audit` instances don't read partial data.
-        with NamedTemporaryFile(delete=False, dir=os.path.dirname(name)) as io:
-            io.write(value)
-
-            # NOTE(ww): Similar to what `pip` does in `adjacent_tmp_file`.
-            io.flush()
-            os.fsync(io.fileno())
-
-        # NOTE(ww): Windows won't let us rename the temporary file until it's closed,
-        # which is why we call `os.replace()` here rather than in the `with` block above.
-        os.replace(io.name, name)
 
     def delete(self, key: str) -> None:  # pragma: no cover
         try:
@@ -165,6 +287,10 @@ def caching_session(cache_dir: Path | None, *, use_pip: bool = False) -> request
     When `use_pip` is `True`, `caching_session` will attempt to discover `pip`'s cache
     directory, falling back on the internal `pip-audit` cache directory if the user's
     version of `pip` is too old.
+
+    The on-disk cache format used is whichever format the resolved directory's `pip`
+    (if any) actually uses: `http-v2` (`_SafeFileCache`) for `pip` >= 23.3, or the
+    legacy single-file format (`_LegacySafeFileCache`) for older `pip` versions.
     """
 
     # We limit the number of redirects to 5, since the services we connect to
@@ -172,7 +298,11 @@ def caching_session(cache_dir: Path | None, *, use_pip: bool = False) -> request
     inner_session = requests.Session()
     inner_session.max_redirects = 5
 
-    return CacheControl(
-        inner_session,
-        cache=_SafeFileCache(_get_cache_dir(cache_dir, use_pip=use_pip)),
-    )
+    resolved_cache_dir, use_legacy_format = _get_cache_dir(cache_dir, use_pip=use_pip)
+    cache: SeparateBodyBaseCache | FileCache
+    if use_legacy_format:
+        cache = _LegacySafeFileCache(resolved_cache_dir)
+    else:
+        cache = _SafeFileCache(resolved_cache_dir)
+
+    return CacheControl(inner_session, cache=cache)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,37 +1,72 @@
 from pathlib import Path
 
 import pretend  # type: ignore
+from cachecontrol.caches import FileCache, SeparateBodyFileCache
 from packaging.version import Version
+from pip._internal.network.cache import SafeFileCache as _PipSafeFileCache
 from platformdirs import user_cache_path
 
 import pip_audit._cache as cache
-from pip_audit._cache import _get_cache_dir, _get_pip_cache
+from pip_audit._cache import (
+    _get_cache_dir,
+    _get_pip_cache,
+    _LegacySafeFileCache,
+    _SafeFileCache,
+    caching_session,
+)
 
 
 def test_get_cache_dir(monkeypatch):
-    # When we supply a cache directory, always use that
+    # When we supply a cache directory, always use that. It isn't shared with a `pip`
+    # cache, so it always uses the current (non-legacy) cache format.
     cache_dir = Path("/tmp/foo/cache_dir")
-    assert _get_cache_dir(cache_dir) == cache_dir
+    assert _get_cache_dir(cache_dir) == (cache_dir, False)
 
-    cache_dir = Path("/fake/pip/cache/dir")
-    get_pip_cache = pretend.call_recorder(lambda: cache_dir)
+    pip_cache_dir = Path("/fake/pip/cache/dir/http-v2")
+    get_pip_cache = pretend.call_recorder(lambda: (pip_cache_dir, False))
     monkeypatch.setattr(cache, "_get_pip_cache", get_pip_cache)
 
     # When `pip cache dir` works, we use it. In this case, it's mocked.
-    assert _get_cache_dir(None, use_pip=True) == cache_dir
+    assert _get_cache_dir(None, use_pip=True) == (pip_cache_dir, False)
 
 
 def test_get_pip_cache():
-    # Actually running `pip cache dir` gets us some path that ends with "http"
-    cache_dir = _get_pip_cache()
-    assert cache_dir.stem == "http"
+    # Actually running `pip cache dir` gets us a path within whichever cache format the
+    # installed `pip` actually uses.
+    cache_dir, is_legacy = _get_pip_cache()
+    if cache._PIP_VERSION >= cache._MINIMUM_PIP_HTTP_V2_VERSION:
+        assert cache_dir.name == "http-v2"
+        assert is_legacy is False
+    else:
+        assert cache_dir.name == "http"
+        assert is_legacy is True
+
+
+def test_get_pip_cache_uses_http_v2_for_pip_23_3_and_newer(monkeypatch):
+    # `pip` 23.3 (https://github.com/pypa/pip/pull/11143) introduced the `http-v2`
+    # cache directory; every `pip` since should use it.
+    monkeypatch.setattr(cache, "_PIP_VERSION", Version("23.3"))
+    cache_dir, is_legacy = _get_pip_cache()
+    assert cache_dir.name == "http-v2"
+    assert is_legacy is False
+
+
+def test_get_pip_cache_uses_legacy_http_for_older_pip(monkeypatch):
+    # `pip` versions older than 23.3 never write to `http-v2`, so we have to keep
+    # reading/writing their legacy `http` cache to actually share a warm cache.
+    monkeypatch.setattr(cache, "_PIP_VERSION", Version("23.2"))
+    cache_dir, is_legacy = _get_pip_cache()
+    assert cache_dir.name == "http"
+    assert is_legacy is True
 
 
 def test_get_cache_dir_do_not_use_pip():
     expected = user_cache_path("pip-audit", appauthor=False)
 
-    # Even with None, we never use the pip cache if we're told not to.
-    assert _get_cache_dir(None, use_pip=False) == expected
+    # Even with None, we never use the pip cache if we're told not to. This directory
+    # isn't shared with any particular `pip` version, so it always uses the current
+    # cache format.
+    assert _get_cache_dir(None, use_pip=False) == (expected, False)
 
 
 def test_get_cache_dir_pip_disabled_in_environment(monkeypatch):
@@ -40,7 +75,7 @@ def test_get_cache_dir_pip_disabled_in_environment(monkeypatch):
     expected = user_cache_path("pip-audit", appauthor=False)
 
     # Even with use_pip=True, we avoid pip's cache if the environment tells us to.
-    assert _get_cache_dir(None, use_pip=True) == expected
+    assert _get_cache_dir(None, use_pip=True) == (expected, False)
 
 
 def test_get_cache_dir_old_pip(monkeypatch):
@@ -49,9 +84,10 @@ def test_get_cache_dir_old_pip(monkeypatch):
 
     # In this case, we can't query `pip` to figure out where its HTTP cache is
     # Instead, we use `~/.pip-audit-cache`
-    cache_dir = _get_cache_dir(None)
+    cache_dir, is_legacy = _get_cache_dir(None)
     expected = user_cache_path("pip-audit", appauthor=False)
     assert cache_dir == expected
+    assert is_legacy is False
 
 
 def test_cache_warns_about_old_pip(monkeypatch, cache_dir):
@@ -78,3 +114,121 @@ def test_delete_legacy_cache_dir(monkeypatch, tmp_path):
 
     _get_cache_dir(None, use_pip=False)
     assert not legacy.exists()
+
+
+def test_caching_session_selects_v2_cache_backend(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_get_cache_dir", lambda *a, **kw: (tmp_path, False))
+    session = caching_session(None)
+    assert isinstance(session.adapters["https://"].cache, _SafeFileCache)
+
+
+def test_caching_session_selects_legacy_cache_backend(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_get_cache_dir", lambda *a, **kw: (tmp_path, True))
+    session = caching_session(None)
+    assert isinstance(session.adapters["https://"].cache, _LegacySafeFileCache)
+
+
+class TestSafeFileCache:
+    """Tests for `_SafeFileCache`, which mirrors `pip`'s current (`http-v2`) format."""
+
+    def test_round_trip(self, tmp_path):
+        c = _SafeFileCache(tmp_path)
+        assert c.get("some-key") is None
+        assert c.get_body("some-key") is None
+
+        c.set("some-key", b"metadata")
+        c.set_body("some-key", b"body")
+
+        assert c.get("some-key") == b"metadata"
+        body = c.get_body("some-key")
+        assert body is not None
+        assert body.read() == b"body"
+
+    def test_entry_requires_both_metadata_and_body(self, tmp_path):
+        # Mirrors `pip`'s own `SafeFileCache`: an entry is only valid once *both* its
+        # metadata and its body have been written. A metadata-only file (e.g. a `set()`
+        # whose matching `set_body()` hasn't landed yet, or a stale entry written by
+        # `_LegacySafeFileCache`, which never writes a `.body` file) must read as a miss.
+        c = _SafeFileCache(tmp_path)
+        c.set("some-key", b"metadata")
+        assert c.get("some-key") is None
+        assert c.get_body("some-key") is None
+
+    def test_delete(self, tmp_path):
+        c = _SafeFileCache(tmp_path)
+        c.set("some-key", b"metadata")
+        c.set_body("some-key", b"body")
+
+        c.delete("some-key")
+
+        assert c.get("some-key") is None
+        assert c.get_body("some-key") is None
+
+        # Deleting a nonexistent key is a no-op, not an error.
+        c.delete("some-other-key")
+
+    def test_matches_cachecontrol_hashing(self, tmp_path):
+        # The on-disk path for a given key must match `cachecontrol`'s own
+        # `SeparateBodyFileCache`, since that's what `pip`'s `SafeFileCache` itself
+        # uses to compute cache paths.
+        ours = _SafeFileCache(tmp_path)
+        theirs = SeparateBodyFileCache(str(tmp_path))
+
+        assert ours._get_cache_path("some-key") == theirs._fn("some-key")
+
+    def test_interop_with_real_pip_safe_file_cache(self, tmp_path):
+        # `_SafeFileCache` is meant to be a "rough mirror" of `pip`'s actual
+        # `SafeFileCache` (`pip._internal.network.cache.SafeFileCache`), close enough
+        # that the two can share a single cache directory. We verify that directly
+        # against the real, installed `pip`, rather than against our own understanding
+        # of the format.
+        ours = _SafeFileCache(tmp_path)
+        theirs = _PipSafeFileCache(str(tmp_path))
+
+        # A response `pip` wrote can be read back by us...
+        theirs.set("shared-key", b"pip-metadata")
+        theirs.set_body("shared-key", b"pip-body")
+        assert ours.get("shared-key") == b"pip-metadata"
+        body = ours.get_body("shared-key")
+        assert body is not None
+        assert body.read() == b"pip-body"
+
+        # ...and a response we wrote can be read back by `pip`.
+        ours.set("our-key", b"our-metadata")
+        ours.set_body("our-key", b"our-body")
+        assert theirs.get("our-key") == b"our-metadata"
+        pip_body = theirs.get_body("our-key")
+        assert pip_body is not None
+        assert pip_body.read() == b"our-body"
+
+
+class TestLegacySafeFileCache:
+    """Tests for `_LegacySafeFileCache`, which mirrors `pip`'s pre-23.3 `http` format."""
+
+    def test_round_trip(self, tmp_path):
+        c = _LegacySafeFileCache(tmp_path)
+        assert c.get("some-key") is None
+
+        c.set("some-key", b"a serialized response")
+        assert c.get("some-key") == b"a serialized response"
+
+    def test_delete(self, tmp_path):
+        c = _LegacySafeFileCache(tmp_path)
+        c.set("some-key", b"a serialized response")
+
+        c.delete("some-key")
+        assert c.get("some-key") is None
+
+    def test_interop_with_cachecontrol_file_cache(self, tmp_path):
+        # `_LegacySafeFileCache` mirrors `pip`'s pre-23.3 `SafeFileCache`, which is
+        # itself a copy of `cachecontrol`'s own combined-file `FileCache` format. We
+        # verify interop against the real, installed `cachecontrol.caches.FileCache`,
+        # rather than against our own understanding of the format.
+        ours = _LegacySafeFileCache(tmp_path)
+        theirs = FileCache(str(tmp_path))
+
+        theirs.set("shared-key", b"a combined response")
+        assert ours.get("shared-key") == b"a combined response"
+
+        ours.set("our-key", b"our combined response")
+        assert theirs.get("our-key") == b"our combined response"


### PR DESCRIPTION
<!-- PR title: fix: read and write pip's http-v2 cache (#794) -->

**You set the work.** #794: pip-audit still only uses pip's legacy `http` cache, which pip stopped populating when it adopted `http-v2` — switch `_cache.py` to mimic and reuse the new format.

**It's done.** `_SafeFileCache` now mirrors pip's current `SafeFileCache` (separate metadata + `.body` files). First, the gap was re-verified as live: the related caching PR #814 only moved pip-audit's own fallback directory and never touched the pip-cache path — so on any pip ≥ 23.3 (Oct 2023), pip-audit has been reading a directory pip no longer writes. One design addition beyond the literal ask: the backend is version-gated, because writing new-format entries into a pre-23.3 pip's `http` directory would make that pip deserialize metadata-only blobs as full responses — old pips keep the legacy backend, new pips get `http-v2`.

**Here's the evidence.**

- Fresh clone at `82bbfe24`, patch applied, dependencies installed, then the network was disconnected.
- Offline suite in a clean `python:3.12-bookworm` container: **220 passed**, including 12 new cache tests with interop round-trips against the *actually installed* `pip._internal.network.cache.SafeFileCache` (not invented mocks). 8 virtualenv-builder tests need network and fail offline — the identical 8 fail on unpatched base in the same container (receipt in the verification record); the solve machine's full-network run passed 251/251.
- mypy, ruff, interrogate (100% docstrings), typos — all clean. Non-vacuity checked: reverting the source with the new tests in place makes them fail to collect.
- Manual live round-trip against pypi.org confirmed the on-disk layout matches pip's real `http-v2` format (sharded hash path + separate `.body`).

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `82bbfe2490eaa55e2a903a6041e12e9932b7285a` |
| Container | `python:3.12-bookworm@sha256:9bed8554…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f01551220fd980db414ba1d56d82ab7d69a5c7bf8b1c97970386bf828340d2d8bafe69dbf) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f015512209a69958b2e347b695b63e1bd990f00f7717875bc57826c83c8889e52ba093cf1) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0x296f5964fb39e297796cc13939f25e9b5384e58f46edf6007ab736373f5449ab) → [work delivered](https://sepolia.basescan.org/tx/0xfd351223edd3e5f605616e44a1da5384bcde9c8d8f204c6197ba834b40fa2bc8) → [checks passed](https://sepolia.basescan.org/tx/0xef886aae5efcb93c1235d96f11249e86385efe3ea6379e48d8085ae5c166914e) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the fix is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Fixes #794.

Changes in `pip_audit/_cache.py`: new `_SafeFileCache(SeparateBodyBaseCache)` mirroring pip's current implementation; the original class renamed `_LegacySafeFileCache`; `_get_pip_cache()` selects `http-v2` (pip ≥ 23.3) or legacy `http` based on the installed pip version; custom `--cache-dir` and pip-audit's internal cache always use the new format (no interop risk there). No dependency changes — `SeparateBodyBaseCache` already exists in the pinned `CacheControl[filecache] >= 0.13.0` floor (verified against that exact wheel). CHANGELOG entry included.

### Notes for the reviewer

- The version-gate (keeping `_LegacySafeFileCache` for pip 20.1–23.2 users) is my inference from reading pip's source, not something the issue specified — a simpler cut that drops legacy sharing entirely is defensible and ~80 lines smaller; happy to rework that way if you prefer.
- `_MINIMUM_PIP_HTTP_V2_VERSION = Version("23.3")` comes from pip's PR/milestone metadata, not the issue text.
- CI's full OS/Python matrix wasn't run locally — container was linux/arm64 + Python 3.12.
