### PR TITLE
Deduplicate repeated PYSEC vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Deduplicated repeated `PYSEC` vulnerability records in audit output
+  ([#1068](https://github.com/pypa/pip-audit/issues/1068))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -69,28 +69,36 @@ class Auditor:
                 unique_vulns: list[VulnerabilityResult] = []
                 seen_aliases: set[str] = set()
 
+                def add_vulnerability(vuln: VulnerabilityResult) -> None:
+                    """Add a vulnerability result or merge it with a matching one."""
+                    if seen_aliases.intersection(vuln.aliases | {vuln.id}):
+                        idx, previous = next(
+                            (i, result)
+                            for (i, result) in enumerate(unique_vulns)
+                            if result.alias_of(vuln)
+                        )
+                        unique_vulns[idx] = previous.merge_aliases(vuln)
+                        return
+
+                    seen_aliases.update(vuln.aliases | {vuln.id})
+                    unique_vulns.append(vuln)
+
                 # First pass, add all PYSEC vulnerabilities and track their
                 # alias sets.
                 for v in vulns:
                     if not v.id.startswith("PYSEC"):
                         continue
 
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
+                    add_vulnerability(v)
 
                 # Second pass: add any non-PYSEC vulnerabilities.
                 for v in vulns:
+                    if v.id.startswith("PYSEC"):
+                        continue
+
                     # If we've already seen this vulnerability by another name,
                     # don't add it. Instead, find the previous result and update
                     # its alias set.
-                    if seen_aliases.intersection(v.aliases | {v.id}):
-                        idx, previous = next(
-                            (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
-                        )
-                        unique_vulns[idx] = previous.merge_aliases(v)
-                        continue
-
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
+                    add_vulnerability(v)
 
                 yield dep, unique_vulns

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -87,6 +87,35 @@ def test_audit_dedupes_aliases(dep_source, vulns):
     assert results[0][1][0].id == "PYSEC-0"
 
 
+def test_audit_dedupes_repeated_pysec_ids(dep_source):
+    class Service(VulnerabilityService):
+        def query(self, spec):
+            return (
+                spec,
+                [
+                    VulnerabilityResult(
+                        id="PYSEC-0",
+                        description="first description",
+                        fix_versions=[Version("1.1.0")],
+                        aliases={"CVE-XXXX-YYYYY"},
+                    ),
+                    VulnerabilityResult(
+                        id="PYSEC-0",
+                        description="second description",
+                        fix_versions=[Version("1.1.0")],
+                        aliases={"GHSA-XXXX-YYYY-YYYY"},
+                    ),
+                ],
+            )
+
+    results = list(Auditor(Service()).audit(dep_source()))
+
+    assert len(results) == 1
+    assert len(results[0][1]) == 1
+    assert results[0][1][0].id == "PYSEC-0"
+    assert results[0][1][0].aliases == {"CVE-XXXX-YYYYY", "GHSA-XXXX-YYYY-YYYY"}
+
+
 @pytest.mark.parametrize(
     "vulns",
     itertools.permutations(


### PR DESCRIPTION
## Summary

Fixes #1068.

`Auditor.audit()` already de-duplicates non-PYSEC records against the PYSEC-priority results, but its initial PYSEC pass appended every record unconditionally. When a vulnerability source returned the same PYSEC ID more than once, those duplicates therefore reached every output format.

This reuses the existing alias-merging behavior for both passes. Repeated PYSEC IDs now produce one result with the combined aliases while preserving PYSEC priority. A regression covers duplicate PYSEC records with different descriptions and aliases.

## Validation

- `python -m pytest test/test_audit.py -q` — 11 passed
- Non-requirements test suite — 173 passed
- `python -m pytest test/dependency_source/test_pip.py test/dependency_source/test_pyproject.py -q` — 16 passed
- `python -m pytest test/test_virtual_env.py -q` — 5 passed
- Ruff format and lint, mypy, interrogate (100% documentation coverage), typos, and `git diff --check` passed

The requirements-source test group did not complete within three minutes in the local Windows environment, so it is not reported as passing. The separate Unix-specific subprocess test uses the `false` command and was not run on Windows.