### PR TITLE
fix(audit): deduplicate results that share a PYSEC id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Deduplicate OSV vulnerability records that share a `PYSEC` identifier
+  ([#1093](https://github.com/pypa/pip-audit/pull/1093)).
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -77,7 +77,9 @@ class Auditor:
                         idx, previous = next(
                             (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
                         )
-                        unique_vulns[idx] = previous.merge_aliases(v)
+                        merged = previous.merge_aliases(v)
+                        unique_vulns[idx] = merged
+                        seen_aliases.update(merged.aliases | {merged.id})
                         return
 
                     seen_aliases.update(v.aliases | {v.id})

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -69,17 +69,7 @@ class Auditor:
                 unique_vulns: list[VulnerabilityResult] = []
                 seen_aliases: set[str] = set()
 
-                # First pass, add all PYSEC vulnerabilities and track their
-                # alias sets.
-                for v in vulns:
-                    if not v.id.startswith("PYSEC"):
-                        continue
-
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
-
-                # Second pass: add any non-PYSEC vulnerabilities.
-                for v in vulns:
+                def add_or_merge(v: VulnerabilityResult) -> None:
                     # If we've already seen this vulnerability by another name,
                     # don't add it. Instead, find the previous result and update
                     # its alias set.
@@ -88,9 +78,22 @@ class Auditor:
                             (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
                         )
                         unique_vulns[idx] = previous.merge_aliases(v)
-                        continue
+                        return
 
                     seen_aliases.update(v.aliases | {v.id})
                     unique_vulns.append(v)
+
+                # First pass, add all PYSEC vulnerabilities and track their
+                # alias sets. Two PYSEC results can describe the same
+                # vulnerability, so they are deduplicated like the rest.
+                for v in vulns:
+                    if not v.id.startswith("PYSEC"):
+                        continue
+
+                    add_or_merge(v)
+
+                # Second pass: add any non-PYSEC vulnerabilities.
+                for v in vulns:
+                    add_or_merge(v)
 
                 yield dep, unique_vulns

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -171,3 +171,43 @@ def test_audit_dedupes_repeated_pysec_ids(dep_source, vulns):
 
     # Aliases from both copies are kept.
     assert results[0][1][0].aliases == {"CVE-XXXX-YYYYY", "GHSA-xxxx-yyyy-zzzz"}
+
+
+def test_audit_dedupes_alias_of_repeated_pysec_id(dep_source):
+    vulns = [
+        VulnerabilityResult(
+            id="PYSEC-0",
+            description="first copy",
+            fix_versions=[Version("1.1.0")],
+            aliases={"CVE-XXXX-YYYYY"},
+        ),
+        VulnerabilityResult(
+            id="PYSEC-0",
+            description="second copy",
+            fix_versions=[Version("1.1.0")],
+            aliases={"GHSA-xxxx-yyyy-zzzz"},
+        ),
+        VulnerabilityResult(
+            id="GHSA-xxxx-yyyy-zzzz",
+            description="alias of the second copy",
+            fix_versions=[Version("1.1.0")],
+            aliases=set(),
+        ),
+    ]
+
+    class Service(VulnerabilityService):
+        def query(self, spec):
+            return spec, vulns
+
+    service = Service()
+    source = dep_source()
+
+    auditor = Auditor(service)
+    results = list(auditor.audit(source))
+
+    # The alias introduced by the second PYSEC record is tracked when the two
+    # records are merged, so a later record using that alias is also deduped.
+    assert len(results) == 1
+    assert len(results[0][1]) == 1
+    assert results[0][1][0].id == "PYSEC-0"
+    assert results[0][1][0].aliases == {"CVE-XXXX-YYYYY", "GHSA-xxxx-yyyy-zzzz"}

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -130,3 +130,44 @@ def test_audit_dedupes_aliases_by_id(dep_source, vulns):
 
     # The result contains the merged alias set for all aliases.
     assert results[0][1][0].aliases == {"FAKE-1", "CVE-XXXX-YYYYY"}
+
+
+@pytest.mark.parametrize(
+    "vulns",
+    itertools.permutations(
+        [
+            # The same vulnerability, returned twice with different descriptions:
+            # OSV can serve two records that share a PYSEC identifier.
+            VulnerabilityResult(
+                id="PYSEC-0",
+                description="first copy",
+                fix_versions=[Version("1.1.0")],
+                aliases={"CVE-XXXX-YYYYY"},
+            ),
+            VulnerabilityResult(
+                id="PYSEC-0",
+                description="second copy",
+                fix_versions=[Version("1.1.0")],
+                aliases={"GHSA-xxxx-yyyy-zzzz"},
+            ),
+        ]
+    ),
+)
+def test_audit_dedupes_repeated_pysec_ids(dep_source, vulns):
+    class Service(VulnerabilityService):
+        def query(self, spec):
+            return spec, vulns
+
+    service = Service()
+    source = dep_source()
+
+    auditor = Auditor(service)
+    results = list(auditor.audit(source))
+
+    # One dependency, one unique vulnerability result for that dependency.
+    assert len(results) == 1
+    assert len(results[0][1]) == 1
+    assert results[0][1][0].id == "PYSEC-0"
+
+    # Aliases from both copies are kept.
+    assert results[0][1][0].aliases == {"CVE-XXXX-YYYYY", "GHSA-xxxx-yyyy-zzzz"}


### PR DESCRIPTION
Fixes #1068

The dedup in `Auditor.audit` runs in two passes, and only the second one deduplicates:

```python
# First pass, add all PYSEC vulnerabilities and track their alias sets.
for v in vulns:
    if not v.id.startswith("PYSEC"):
        continue
    seen_aliases.update(v.aliases | {v.id})
    unique_vulns.append(v)   # <- appended unconditionally
```

So when the service returns two records that resolve to the same PYSEC identifier — which is what
happens for `cryptography==35.0.0` with `PYSEC-2023-11`, `PYSEC-2023-254` and `PYSEC-2026-35` — both are
appended and the row appears twice. The reporter noticed the copies carry different `description`
fields, which fits: they are separate OSV records sharing a PYSEC id.

The merge branch that the second pass already uses is now applied in both passes, via a small
`add_or_merge()` helper. Nothing else changes: the PYSEC-first ordering is preserved, and aliases from
the discarded copy are merged into the kept one.

### Before / after

New test `test_audit_dedupes_repeated_pysec_ids` — two results with the same `PYSEC-0` id and different
alias sets, in both orderings:

```
before:  FAILED test/test_audit.py::test_audit_dedupes_repeated_pysec_ids[vulns0]
         FAILED test/test_audit.py::test_audit_dedupes_repeated_pysec_ids[vulns1]
         2 failed, 10 deselected

after:   12 passed
```

The test also asserts that the surviving result keeps the aliases from both copies
(`{"CVE-XXXX-YYYYY", "GHSA-xxxx-yyyy-zzzz"}`), so information is merged rather than dropped.

AI-assisted (LLM used for drafting); the change and both runs above are mine.
