### PR TITLE
fix(requirement): do not pin a fix into files that never listed it

### DIFF
--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -201,12 +201,21 @@ class RequirementSource(DependencySource):
 
             try:
                 # Now fix the files inplace
+                explicitly_listed = False
                 for filename in self._filenames:
                     self.state.update_state(
                         f"Fixing dependency {fix_version.dep.name} ({fix_version.dep.version} => "
                         f"{fix_version.version})"
                     )
-                    self._fix_file(filename, fix_version)
+                    explicitly_listed |= self._fix_file(filename, fix_version)
+
+                # The vulnerable dependency may not be explicitly listed in any of the
+                # requirements files if it is a subdependency of a requirement. In that case we
+                # add an explicit pin, but only to one file: the audited environment is the union
+                # of all the inputs, so repeating the pin in every file would add the dependency
+                # to files that never contained it.
+                if not explicitly_listed:
+                    self._add_explicit_fix(self._filenames[0], fix_version)
             except Exception as e:
                 logger.warning(
                     f"encountered an exception while applying fixes, recovering original files: {e}"
@@ -214,7 +223,9 @@ class RequirementSource(DependencySource):
                 self._recover_files(tmp_files)
                 raise e
 
-    def _fix_file(self, filename: Path, fix_version: ResolvedFixVersion) -> None:
+    def _fix_file(self, filename: Path, fix_version: ResolvedFixVersion) -> bool:
+        # Returns whether the fixed dependency was explicitly listed in this file.
+        #
         # Reparse the requirements file. We want to rewrite each line to the new requirements file
         # and only modify the lines that we're fixing.
         #
@@ -262,23 +273,21 @@ class RequirementSource(DependencySource):
                         req.req.specifier = SpecifierSet(f"=={fix_version.version}")
                 print(req.dumps(), file=f)
 
-            # The vulnerable dependency may not be explicitly listed in the requirements file if it
-            # is a subdependency of a requirement. In this case, we should explicitly add the fixed
-            # dependency into the requirements file.
-            #
-            # To know whether this is the case, we'll need to resolve dependencies if we haven't
-            # already in order to figure out whether this subdependency belongs to this file or
-            # another.
-            if not found:
-                logger.warning(
-                    "added fixed subdependency explicitly to requirements file "
-                    f"{filename}: {fix_version.dep.canonical_name}"
-                )
-                print(
-                    "    # pip-audit: subdependency explicitly fixed",
-                    file=f,
-                )
-                print(f"{fix_version.dep.canonical_name}=={fix_version.version}", file=f)
+        return found
+
+    def _add_explicit_fix(self, filename: Path, fix_version: ResolvedFixVersion) -> None:
+        # The vulnerable dependency was not explicitly listed in any requirements file, so it is
+        # a subdependency of one of the requirements. Add an explicit pin for it.
+        logger.warning(
+            "added fixed subdependency explicitly to requirements file "
+            f"{filename}: {fix_version.dep.canonical_name}"
+        )
+        with filename.open("a") as f:
+            print(
+                "    # pip-audit: subdependency explicitly fixed",
+                file=f,
+            )
+            print(f"{fix_version.dep.canonical_name}=={fix_version.version}", file=f)
 
     def _recover_files(self, tmp_files: list[IO[str]]) -> None:
         for filename, tmp_file in zip(self._filenames, tmp_files, strict=True):

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -260,6 +260,41 @@ def test_requirement_source_fix_multiple_files(req_file):
     )
 
 
+def test_requirement_source_fix_does_not_touch_unrelated_files(req_file):
+    # The fixed dependency is listed in the first file only, so the second file must be left
+    # alone rather than gaining a pin it never had (#633).
+    _check_fixes(
+        ["flask==0.5", "requests==2.0"],
+        ["flask==1.0", "requests==2.0"],
+        [req_file(), req_file()],
+        [
+            ResolvedFixVersion(
+                dep=ResolvedDependency(name="flask", version=Version("0.5")),
+                version=Version("1.0"),
+            )
+        ],
+    )
+
+
+def test_requirement_source_fix_explicit_subdep_added_once(req_file):
+    # A subdependency that is listed in none of the files gets pinned exactly once: the audited
+    # environment is the union of all inputs, so one pin is enough (#633).
+    _check_fixes(
+        ["flask==1.0", "requests==2.0"],
+        [
+            "flask==1.0\n    # pip-audit: subdependency explicitly fixed\njinja2==4.0.0",
+            "requests==2.0",
+        ],
+        [req_file(), req_file()],
+        [
+            ResolvedFixVersion(
+                dep=ResolvedDependency(name="jinja2", version=Version("3.0.0")),
+                version=Version("4.0.0"),
+            )
+        ],
+    )
+
+
 def test_requirement_source_fix_specifier_match(req_file):
     _check_fixes(
         ["flask<1.0", "requests==2.0\nflask<=0.6"],


### PR DESCRIPTION
Fixes #633

`--fix` writes the pin into every file passed with `-r`, including files that never mentioned the
package. With the reporter's repro (`pip-audit -r a.txt -r b.txt --fix --no-deps`, `httpx` only in
`a.txt`), `b.txt` comes back with an `httpx` pin appended.

The cause is in `RequirementSource.fix()`: it calls `_fix_file()` once per file, and `_fix_file()`
ends with a per-file fallback — if the package wasn't listed in *this* file, append it as an
explicitly-pinned subdependency. So for N files where the package is listed in one, the other N-1
each get a spurious pin. The existing comment above that branch already flagged the gap:

> To know whether this is the case, we'll need to resolve dependencies if we haven't already in
> order to figure out whether this subdependency belongs to this file or another.

This PR makes the decision once, across all files, instead of once per file:

* `_fix_file()` now returns whether the package was explicitly listed in that file, and no longer
  appends anything.
* `fix()` collects those results. The explicit pin is added only when the package was listed in
  **no** file, and then only to one file — the audited environment is the union of all inputs, so
  a single pin is enough and repeating it in every file is what caused the bug.

Rewriting of files that *do* list the package is untouched, so the normal path is unchanged. The
recovery-on-exception behaviour is unchanged too: the new append still runs inside the same `try`.

### Before / after

Two new tests in `test/dependency_source/test_requirement.py` — one for the reported case, one for
a genuine subdependency across two files:

```
before:  FAILED test_requirement_source_fix_does_not_touch_unrelated_files
         FAILED test_requirement_source_fix_explicit_subdep_added_once
         2 failed, 45 deselected

after:   47 passed
```

The "before" failure output shows the mechanism directly — two warnings, one per file:

```
WARNING  added fixed subdependency explicitly to requirements file /tmp/tmp7w4vhf29: jinja2
WARNING  added fixed subdependency explicitly to requirements file /tmp/tmp0ytg8swx: jinja2
```

One open question for you: when the package is listed nowhere and several files are given, I pin it
in the first file. That is arbitrary — it just has to land somewhere, and `-r a -r b` resolves as one
environment. If you would rather it went into the file whose top-level requirement pulls the
subdependency in, that needs resolution data that `fix()` deliberately no longer has (see
`test_requirement_source_fix_explicit_subdep_resolver_error`), so it would be a larger change. Happy
to go that way if you prefer.

AI-assisted (LLM used for drafting); the change and both runs above are mine.
