### PR TITLE
fix: skip explicit subdep pins in unrelated requirements files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `--fix` no longer appends an explicit pin to requirements files that do not
+  list the fixed package when auditing multiple `-r` inputs
+  ([#633](https://github.com/pypa/pip-audit/issues/633))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -200,13 +200,20 @@ class RequirementSource(DependencySource):
                     shutil.copyfileobj(f, tmp_file)
 
             try:
-                # Now fix the files inplace
+                # Now fix the files inplace.
+                #
+                # When fixing a package that isn't listed in a given requirements file, we may need
+                # to add an explicit pin (vulnerable transitive). With multiple requirements files
+                # we can't attribute that transitive to a specific file without resolving again, so
+                # only allow those explicit adds for the single-file case. Multi-file fixes still
+                # update any file that already lists the package.
+                allow_explicit_add = len(self._filenames) == 1
                 for filename in self._filenames:
                     self.state.update_state(
                         f"Fixing dependency {fix_version.dep.name} ({fix_version.dep.version} => "
                         f"{fix_version.version})"
                     )
-                    self._fix_file(filename, fix_version)
+                    self._fix_file(filename, fix_version, allow_explicit_add=allow_explicit_add)
             except Exception as e:
                 logger.warning(
                     f"encountered an exception while applying fixes, recovering original files: {e}"
@@ -214,7 +221,13 @@ class RequirementSource(DependencySource):
                 self._recover_files(tmp_files)
                 raise e
 
-    def _fix_file(self, filename: Path, fix_version: ResolvedFixVersion) -> None:
+    def _fix_file(
+        self,
+        filename: Path,
+        fix_version: ResolvedFixVersion,
+        *,
+        allow_explicit_add: bool = True,
+    ) -> None:
         # Reparse the requirements file. We want to rewrite each line to the new requirements file
         # and only modify the lines that we're fixing.
         #
@@ -264,12 +277,8 @@ class RequirementSource(DependencySource):
 
             # The vulnerable dependency may not be explicitly listed in the requirements file if it
             # is a subdependency of a requirement. In this case, we should explicitly add the fixed
-            # dependency into the requirements file.
-            #
-            # To know whether this is the case, we'll need to resolve dependencies if we haven't
-            # already in order to figure out whether this subdependency belongs to this file or
-            # another.
-            if not found:
+            # dependency into the requirements file — but only when callers allow it (see `fix`).
+            if not found and allow_explicit_add:
                 logger.warning(
                     "added fixed subdependency explicitly to requirements file "
                     f"{filename}: {fix_version.dep.canonical_name}"

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -260,6 +260,22 @@ def test_requirement_source_fix_multiple_files(req_file):
     )
 
 
+def test_requirement_source_fix_skips_unrelated_files(req_file):
+    # Regression test for #633: when fixing a package listed in only one of several
+    # requirements files, do not append an explicit pin to the unrelated files.
+    _check_fixes(
+        ["httpx==0.13.3", "astpretty==3.0.0"],
+        ["httpx==0.23.0", "astpretty==3.0.0"],
+        [req_file(), req_file()],
+        [
+            ResolvedFixVersion(
+                dep=ResolvedDependency(name="httpx", version=Version("0.13.3")),
+                version=Version("0.23.0"),
+            )
+        ],
+    )
+
+
 def test_requirement_source_fix_specifier_match(req_file):
     _check_fixes(
         ["flask<1.0", "requests==2.0\nflask<=0.6"],


### PR DESCRIPTION
## Summary
- Stop `--fix` from appending an explicit pin to requirements files that do not list the fixed package when multiple `-r` inputs are used
- Keep single-file transitive (subdependency) pinning behavior unchanged
- Fixes #633

I claimed this on the issue yesterday and can still reproduce the multi-file behavior on `main`.

## Test plan
- [x] `pytest test/dependency_source/test_requirement.py -k fix`
- [x] New regression: `test_requirement_source_fix_skips_unrelated_files`
- [x] `ruff format --check` / `ruff check` / `mypy` on changed code

Made with [Cursor](https://cursor.com)