### PR TITLE
fix: dedupe repeated PYSEC vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed duplicate vulnerability results when a vulnerability service returns
+  repeated `PYSEC` records with the same aliases.
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_audit.py
+++ b/pip_audit/_audit.py
@@ -69,17 +69,8 @@ class Auditor:
                 unique_vulns: list[VulnerabilityResult] = []
                 seen_aliases: set[str] = set()
 
-                # First pass, add all PYSEC vulnerabilities and track their
-                # alias sets.
-                for v in vulns:
-                    if not v.id.startswith("PYSEC"):
-                        continue
-
-                    seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
-
-                # Second pass: add any non-PYSEC vulnerabilities.
-                for v in vulns:
+                def dedupe(v: VulnerabilityResult) -> None:
+                    """Add a vulnerability result, merging it with any existing alias."""
                     # If we've already seen this vulnerability by another name,
                     # don't add it. Instead, find the previous result and update
                     # its alias set.
@@ -88,9 +79,24 @@ class Auditor:
                             (i, p) for (i, p) in enumerate(unique_vulns) if p.alias_of(v)
                         )
                         unique_vulns[idx] = previous.merge_aliases(v)
-                        continue
+                    else:
+                        unique_vulns.append(v)
 
                     seen_aliases.update(v.aliases | {v.id})
-                    unique_vulns.append(v)
+
+                # First pass, add all PYSEC vulnerabilities and track their
+                # alias sets.
+                for v in vulns:
+                    if not v.id.startswith("PYSEC"):
+                        continue
+
+                    dedupe(v)
+
+                # Second pass: add any non-PYSEC vulnerabilities.
+                for v in vulns:
+                    if v.id.startswith("PYSEC"):
+                        continue
+
+                    dedupe(v)
 
                 yield dep, unique_vulns

--- a/test/test_audit.py
+++ b/test/test_audit.py
@@ -130,3 +130,40 @@ def test_audit_dedupes_aliases_by_id(dep_source, vulns):
 
     # The result contains the merged alias set for all aliases.
     assert results[0][1][0].aliases == {"FAKE-1", "CVE-XXXX-YYYYY"}
+
+
+@pytest.mark.parametrize(
+    "vulns",
+    itertools.permutations(
+        [
+            VulnerabilityResult(
+                id="PYSEC-2023-11",
+                description="first description",
+                fix_versions=[Version("39.0.1")],
+                aliases={"CVE-2023-23931", "GHSA-w7pp-m8wf-vj6r"},
+            ),
+            VulnerabilityResult(
+                id="PYSEC-2023-11",
+                description="second description",
+                fix_versions=[Version("39.0.1")],
+                aliases={"CVE-2023-23931", "GHSA-w7pp-m8wf-vj6r"},
+            ),
+        ]
+    ),
+)
+def test_audit_dedupes_duplicate_pysec_results(dep_source, vulns):
+    class Service(VulnerabilityService):
+        def query(self, spec):
+            return spec, vulns
+
+    service = Service()
+    source = dep_source()
+
+    auditor = Auditor(service)
+    results = list(auditor.audit(source))
+
+    # One dependency, one unique vulnerability result for that dependency.
+    assert len(results) == 1
+    assert len(results[0][1]) == 1
+    assert results[0][1][0].id == "PYSEC-2023-11"
+    assert results[0][1][0].aliases == {"CVE-2023-23931", "GHSA-w7pp-m8wf-vj6r"}


### PR DESCRIPTION
## Description

This fixes duplicate vulnerability results when a vulnerability service returns repeated `PYSEC` records with the same vulnerability identity/aliases.

The audit deduplication already merged non-`PYSEC` aliases into preferred `PYSEC` records, but the first pass appended every `PYSEC` record before the second pass. That meant repeated `PYSEC` entries with different descriptions but the same IDs/aliases could still appear multiple times in text and JSON output.

The change now applies the same alias-based merge logic while adding `PYSEC` results, then skips them in the non-`PYSEC` pass.

Fixes #1068.

## Test plan

- [x] RED: `uv run --extra test pytest test/test_audit.py::test_audit_dedupes_duplicate_pysec_results -q` failed with two results before the fix
- [x] GREEN: `uv run --extra test pytest test/test_audit.py::test_audit_dedupes_duplicate_pysec_results -q`
- [x] `uv run --extra test pytest test/test_audit.py -q`
- [x] `uv run --extra test pytest -q` — 241 passed
- [x] `uv run --extra lint ruff format --check pip_audit test`
- [x] `uv run --extra lint ruff check pip_audit test`
- [x] `uv run --extra lint mypy pip_audit`
- [x] `uv run --extra lint interrogate -c pyproject.toml .`
- [x] `uv run --extra lint typos .`
- [x] `git diff --check`
