### PR TITLE
fix: honor --skip-editable before hash checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* `--skip-editable` is now honored before hash enforcement in the
+  `--disable-pip` requirements path, so editable lines are skipped instead of
+  failing for missing hashes
+  ([#1024](https://github.com/pypa/pip-audit/issues/1024))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -300,6 +300,13 @@ class RequirementSource(DependencySource):
         """
         req_specifiers: dict[str, SpecifierSet] = {}
         for req in reqs:
+            # Handle `--skip-editable` before hash enforcement so editable lines aren't
+            # rejected for missing hashes when the user asked to skip them (#1024).
+            if self._skip_editable and req.is_editable:
+                name = req.name if req.name is not None else req.requirement_line.line
+                yield SkippedDependency(name=name, skip_reason="requirement marked as editable")
+                continue
+
             if not req.hash_options and require_hashes:
                 raise RequirementSourceError(f"requirement {req.dumps()} does not contain a hash")
             if req.req is None:
@@ -314,8 +321,6 @@ class RequirementSource(DependencySource):
                     skip_reason="could not deduce package version from URL requirement",
                 )
                 continue
-            if self._skip_editable and req.is_editable:
-                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
             if req.marker is not None and not req.marker.evaluate():
                 # TODO(ww): Remove this `no cover` pragma once we're 3.10+.
                 # See: https://github.com/nedbat/coveragepy/issues/198

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -522,6 +522,46 @@ def test_requirement_source_disable_pip_editable_skip(req_file):
     assert SkippedDependency(name="flask", skip_reason="requirement marked as editable") in specs
 
 
+def test_requirement_source_disable_pip_skip_editable_before_hash_check(req_file):
+    # Regression for #1024: hashed requirements imply --require-hashes, but editable
+    # lines skipped via --skip-editable must not fail for missing hashes.
+    source = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:.\n"
+                "flask==2.0.1 "
+                "--hash=sha256:a6c9c3b5f7c1e4a80e4e5d6c8e8c1a0b0c0d0e0f0a0b0c0d0e0f0a0b0c0d0e0f\n",
+            )
+        ],
+        disable_pip=True,
+        skip_editable=True,
+    )
+
+    specs = list(source.collect())
+    assert any(
+        isinstance(s, SkippedDependency) and s.skip_reason == "requirement marked as editable"
+        for s in specs
+    )
+    assert ResolvedDependency(name="flask", version=Version("2.0.1")) in specs
+
+    # Without --skip-editable, the unhashed editable line fails hash policy.
+    source_strict = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:.\n"
+                "flask==2.0.1 "
+                "--hash=sha256:a6c9c3b5f7c1e4a80e4e5d6c8e8c1a0b0c0d0e0f0a0b0c0d0e0f0a0b0c0d0e0f\n",
+            )
+        ],
+        disable_pip=True,
+        skip_editable=False,
+    )
+    with pytest.raises(DependencySourceError, match="does not contain a hash"):
+        list(source_strict.collect())
+
+
 def test_requirement_source_disable_pip_duplicate_dependencies(req_file):
     source = _init_requirement(
         [(req_file(), "flask==1.0\nflask==1.0")], disable_pip=True, no_deps=True


### PR DESCRIPTION
## Summary
- Honor `--skip-editable` before hash enforcement on the `--disable-pip` requirements path
- Editable lines are skipped instead of failing for missing hashes when hashes are implied
- Fixes #1024
## Test plan
- [x] `pytest test/dependency_source/test_requirement.py -k editable`
- [x] New regression: `test_requirement_source_disable_pip_skip_editable_before_hash_check`
- [x] `ruff` / `mypy` on changed code
