### PR TITLE
feat: add SARIF output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* CLI: The `--format sarif` option has been added, emitting SARIF 2.1.0 reports
+  suitable for code-scanning style integrations
+  ([#206](https://github.com/pypa/pip-audit/issues/206))
+
 ## [2.10.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ with support from Google. This is not an official Google or Trail of Bits produc
 * Support for emitting
   [SBOMs](https://en.wikipedia.org/wiki/Software_bill_of_materials) in
   [CycloneDX](https://cyclonedx.org/) XML or JSON
+* Support for emitting [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+  reports for code-scanning style integrations
 * Support for automatically fixing vulnerable dependencies (`--fix`)
-* Human and machine-readable output formats (columnar, Markdown, JSON)
+* Human and machine-readable output formats (columnar, Markdown, JSON, SARIF)
 * Seamlessly reuses your existing local `pip` caches
 
 ## Installation
@@ -161,7 +163,7 @@ options:
                         (default: False)
   -f FORMAT, --format FORMAT
                         the format to emit audit results in (choices: columns,
-                        json, cyclonedx-json, cyclonedx-xml, markdown)
+                        json, cyclonedx-json, cyclonedx-xml, markdown, sarif)
                         (default: columns)
   -s SERVICE, --vulnerability-service SERVICE
                         the vulnerability service to audit dependencies
@@ -176,14 +178,14 @@ options:
                         on any dependency (default: False)
   --desc [{on,off,auto}]
                         include a description for each vulnerability; `auto`
-                        defaults to `on` for the `json` format. This flag has
-                        no effect on the `cyclonedx-json` or `cyclonedx-xml`
-                        formats. (default: auto)
+                        defaults to `on` for the `json` and `sarif` formats.
+                        This flag has no effect on the `cyclonedx-json` or
+                        `cyclonedx-xml` formats. (default: auto)
   --aliases [{on,off,auto}]
                         includes alias IDs for each vulnerability; `auto`
-                        defaults to `on` for the `json` format. This flag has
-                        no effect on the `cyclonedx-json` or `cyclonedx-xml`
-                        formats. (default: auto)
+                        defaults to `on` for the `json` and `sarif` formats.
+                        This flag has no effect on the `cyclonedx-json` or
+                        `cyclonedx-xml` formats. (default: auto)
   --cache-dir CACHE_DIR
                         the directory to use as an HTTP cache for PyPI; uses
                         the `pip` HTTP cache by default (default: None)
@@ -223,7 +225,7 @@ options:
   --disable-pip         don't use `pip` for dependency resolution; this can
                         only be used with hashed requirements files or if the
                         `--no-deps` flag has been provided (default: False)
-```
+`
 <!-- @end-pip-audit-help@ -->
 
 ### Environment variables

--- a/pip_audit/_cli.py
+++ b/pip_audit/_cli.py
@@ -30,6 +30,7 @@ from pip_audit._format import (
     CycloneDxFormat,
     JsonFormat,
     MarkdownFormat,
+    SarifFormat,
     VulnerabilityFormat,
 )
 from pip_audit._service import EcosystemsService, OsvService, PyPIService
@@ -78,6 +79,7 @@ class OutputFormatChoice(str, enum.Enum):
     CycloneDxJson = "cyclonedx-json"
     CycloneDxXml = "cyclonedx-xml"
     Markdown = "markdown"
+    Sarif = "sarif"
 
     def to_format(self, output_desc: bool, output_aliases: bool) -> VulnerabilityFormat:
         if self is OutputFormatChoice.Columns:
@@ -90,6 +92,8 @@ class OutputFormatChoice(str, enum.Enum):
             return CycloneDxFormat(inner_format=CycloneDxFormat.InnerFormat.Xml)
         elif self is OutputFormatChoice.Markdown:
             return MarkdownFormat(output_desc, output_aliases)
+        elif self is OutputFormatChoice.Sarif:
+            return SarifFormat(output_desc, output_aliases)
         else:
             assert_never(self)  # pragma: no cover
 
@@ -127,7 +131,7 @@ class VulnerabilityDescriptionChoice(str, enum.Enum):
         elif self is VulnerabilityDescriptionChoice.Off:
             return False
         elif self is VulnerabilityDescriptionChoice.Auto:
-            return bool(format_ is OutputFormatChoice.Json)
+            return bool(format_ is OutputFormatChoice.Json or format_ is OutputFormatChoice.Sarif)
         else:
             assert_never(self)  # pragma: no cover
 
@@ -151,7 +155,7 @@ class VulnerabilityAliasChoice(str, enum.Enum):
         elif self is VulnerabilityAliasChoice.Off:
             return False
         elif self is VulnerabilityAliasChoice.Auto:
-            return bool(format_ is OutputFormatChoice.Json)
+            return bool(format_ is OutputFormatChoice.Json or format_ is OutputFormatChoice.Sarif)
         else:
             assert_never(self)  # pragma: no cover
 
@@ -277,7 +281,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         const=VulnerabilityDescriptionChoice.On,
         default=os.environ.get("PIP_AUDIT_DESC", VulnerabilityDescriptionChoice.Auto),
         help="include a description for each vulnerability; "
-        "`auto` defaults to `on` for the `json` format. This flag has no "
+        "`auto` defaults to `on` for the `json` and `sarif` formats. This flag has no "
         "effect on the `cyclonedx-json` or `cyclonedx-xml` formats.",
     )
     parser.add_argument(
@@ -288,7 +292,7 @@ def _parser() -> argparse.ArgumentParser:  # pragma: no cover
         const=VulnerabilityAliasChoice.On,
         default=VulnerabilityAliasChoice.Auto,
         help="includes alias IDs for each vulnerability; "
-        "`auto` defaults to `on` for the `json` format. This flag has no "
+        "`auto` defaults to `on` for the `json` and `sarif` formats. This flag has no "
         "effect on the `cyclonedx-json` or `cyclonedx-xml` formats.",
     )
     parser.add_argument(

--- a/pip_audit/_format/__init__.py
+++ b/pip_audit/_format/__init__.py
@@ -7,6 +7,7 @@ from .cyclonedx import CycloneDxFormat
 from .interface import VulnerabilityFormat
 from .json import JsonFormat
 from .markdown import MarkdownFormat
+from .sarif import SarifFormat
 
 __all__ = [
     "ColumnsFormat",
@@ -14,4 +15,5 @@ __all__ = [
     "VulnerabilityFormat",
     "JsonFormat",
     "MarkdownFormat",
+    "SarifFormat",
 ]

--- a/pip_audit/_format/sarif.py
+++ b/pip_audit/_format/sarif.py
@@ -1,0 +1,137 @@
+"""
+Functionality for formatting vulnerability results as SARIF.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+import pip_audit._fix as fix
+import pip_audit._service as service
+from pip_audit import __version__
+
+from .interface import VulnerabilityFormat, vuln_id_url
+
+logger = logging.getLogger(__name__)
+
+_SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
+_SARIF_VERSION = "2.1.0"
+_TOOL_INFORMATION_URI = "https://github.com/pypa/pip-audit"
+
+
+class SarifFormat(VulnerabilityFormat):
+    """
+    An implementation of `VulnerabilityFormat` that formats vulnerability results as SARIF 2.1.0.
+
+    Source locations (`physicalLocation`) are intentionally omitted: dependency audits often have
+    no stable file/line/column. Schema-valid SARIF without locations is still useful for tooling
+    that consumes the report as an artifact.
+    """
+
+    def __init__(self, output_desc: bool, output_aliases: bool):
+        """
+        Create a new `SarifFormat`.
+
+        `output_desc` controls whether vulnerability descriptions are included in rule metadata
+        and result messages.
+
+        `output_aliases` controls whether alias IDs (such as CVEs) are included in rule properties.
+        """
+        self.output_desc = output_desc
+        self.output_aliases = output_aliases
+
+    @property
+    def is_manifest(self) -> bool:
+        """
+        See `VulnerabilityFormat.is_manifest`.
+        """
+        return True
+
+    def format(
+        self,
+        result: dict[service.Dependency, list[service.VulnerabilityResult]],
+        fixes: list[fix.FixVersion],
+    ) -> str:
+        """
+        Returns a SARIF formatted string for a given mapping of dependencies to vulnerability
+        results.
+
+        See `VulnerabilityFormat.format`.
+        """
+        if fixes:
+            logger.warning("--fix output is unsupported by the SARIF format")
+
+        rules_by_id: dict[str, dict[str, Any]] = {}
+        results: list[dict[str, Any]] = []
+
+        for dep, vulns in result.items():
+            if dep.is_skipped():
+                continue
+
+            dep = cast(service.ResolvedDependency, dep)
+            for vuln in vulns:
+                if vuln.id not in rules_by_id:
+                    rules_by_id[vuln.id] = self._format_rule(vuln)
+                results.append(self._format_result(dep, vuln))
+
+        output: dict[str, Any] = {
+            "$schema": _SARIF_SCHEMA,
+            "version": _SARIF_VERSION,
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "pip-audit",
+                            "version": __version__,
+                            "informationUri": _TOOL_INFORMATION_URI,
+                            "rules": list(rules_by_id.values()),
+                        }
+                    },
+                    "results": results,
+                }
+            ],
+        }
+        return json.dumps(output)
+
+    def _format_rule(self, vuln: service.VulnerabilityResult) -> dict[str, Any]:
+        short_text = vuln.id
+        if self.output_desc and vuln.description:
+            short_text = vuln.description.splitlines()[0][:256]
+
+        rule: dict[str, Any] = {
+            "id": vuln.id,
+            "shortDescription": {"text": short_text},
+            "helpUri": vuln_id_url(vuln.id),
+        }
+        if self.output_desc and vuln.description:
+            rule["fullDescription"] = {"text": vuln.description}
+
+        properties: dict[str, Any] = {}
+        if vuln.fix_versions:
+            properties["fix_versions"] = [str(version) for version in vuln.fix_versions]
+        if self.output_aliases and vuln.aliases:
+            properties["aliases"] = sorted(vuln.aliases)
+        if properties:
+            rule["properties"] = properties
+
+        return rule
+
+    def _format_result(
+        self, dep: service.ResolvedDependency, vuln: service.VulnerabilityResult
+    ) -> dict[str, Any]:
+        message = f"{dep.canonical_name}@{dep.version} is vulnerable to {vuln.id}"
+        if self.output_desc and vuln.description:
+            message = f"{message}: {vuln.description}"
+
+        result: dict[str, Any] = {
+            "ruleId": vuln.id,
+            "level": "error",
+            "message": {"text": message},
+            "properties": {
+                "package": dep.canonical_name,
+                "version": str(dep.version),
+            },
+        }
+        return result

--- a/test/format/test_sarif.py
+++ b/test/format/test_sarif.py
@@ -1,0 +1,82 @@
+import json
+
+import pretend  # type: ignore
+import pytest
+
+import pip_audit._format as format
+from pip_audit import __version__
+
+
+@pytest.mark.parametrize(
+    ("output_desc", "output_aliases"),
+    ([True, False], [False, True], [True, True], [False, False]),
+)
+def test_sarif_manifest(output_desc, output_aliases):
+    fmt = format.SarifFormat(output_desc, output_aliases)
+
+    assert fmt.is_manifest
+
+
+def test_sarif(vuln_data):
+    sarif_format = format.SarifFormat(True, True)
+    payload = json.loads(sarif_format.format(vuln_data, []))
+
+    assert payload["version"] == "2.1.0"
+    assert payload["$schema"] == "https://json.schemastore.org/sarif-2.1.0.json"
+    assert len(payload["runs"]) == 1
+
+    run = payload["runs"][0]
+    driver = run["tool"]["driver"]
+    assert driver["name"] == "pip-audit"
+    assert driver["version"] == __version__
+    assert driver["informationUri"] == "https://github.com/pypa/pip-audit"
+
+    rule_ids = {rule["id"] for rule in driver["rules"]}
+    assert rule_ids == {"VULN-0", "VULN-1", "VULN-2"}
+
+    vuln0 = next(rule for rule in driver["rules"] if rule["id"] == "VULN-0")
+    assert vuln0["fullDescription"]["text"] == "The first vulnerability"
+    assert vuln0["helpUri"] == "https://osv.dev/vulnerability/VULN-0"
+    assert vuln0["properties"]["aliases"] == ["CVE-0000-00000"]
+    assert vuln0["properties"]["fix_versions"] == ["1.1", "1.4"]
+
+    assert len(run["results"]) == 3
+    first = run["results"][0]
+    assert first["ruleId"] == "VULN-0"
+    assert first["level"] == "error"
+    assert first["properties"]["package"] == "foo"
+    assert first["properties"]["version"] == "1.0"
+    assert "physicalLocation" not in first
+    assert "locations" not in first
+
+
+def test_sarif_no_desc_no_aliases(vuln_data):
+    sarif_format = format.SarifFormat(False, False)
+    payload = json.loads(sarif_format.format(vuln_data, []))
+    rules = payload["runs"][0]["tool"]["driver"]["rules"]
+    vuln0 = next(rule for rule in rules if rule["id"] == "VULN-0")
+
+    assert "fullDescription" not in vuln0
+    assert vuln0["shortDescription"]["text"] == "VULN-0"
+    assert "aliases" not in vuln0.get("properties", {})
+    assert vuln0["properties"]["fix_versions"] == ["1.1", "1.4"]
+
+
+def test_sarif_skipped_dep(vuln_data_skipped_dep):
+    sarif_format = format.SarifFormat(False, True)
+    payload = json.loads(sarif_format.format(vuln_data_skipped_dep, []))
+
+    assert len(payload["runs"][0]["results"]) == 1
+    assert payload["runs"][0]["results"][0]["ruleId"] == "VULN-0"
+    assert {rule["id"] for rule in payload["runs"][0]["tool"]["driver"]["rules"]} == {"VULN-0"}
+
+
+def test_sarif_fix_unsupported(vuln_data, fix_data, monkeypatch):
+    logger = pretend.stub(warning=pretend.call_recorder(lambda s: None))
+    monkeypatch.setattr(format.sarif, "logger", logger)
+
+    sarif_format = format.SarifFormat(True, True)
+    payload = json.loads(sarif_format.format(vuln_data, fix_data))
+
+    assert len(payload["runs"][0]["results"]) == 3
+    assert len(logger.warning.calls) == 1

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,6 +40,9 @@ class TestVulnerabilityDescriptionChoice:
     def test_auto_to_bool_for_json(self):
         assert VulnerabilityDescriptionChoice.Auto.to_bool(OutputFormatChoice.Json) is True
 
+    def test_auto_to_bool_for_sarif(self):
+        assert VulnerabilityDescriptionChoice.Auto.to_bool(OutputFormatChoice.Sarif) is True
+
     def test_str(self):
         for choice in VulnerabilityDescriptionChoice:
             assert str(choice) == choice.value
@@ -53,9 +56,13 @@ class TestVulnerabilityAliasChoice:
             assert choice.to_bool(OutputFormatChoice.Columns) in {True, False}
             assert choice.to_bool(OutputFormatChoice.CycloneDxJson) in {True, False}
             assert choice.to_bool(OutputFormatChoice.CycloneDxXml) in {True, False}
+            assert choice.to_bool(OutputFormatChoice.Sarif) in {True, False}
 
     def test_auto_to_bool_for_json(self):
         assert VulnerabilityAliasChoice.Auto.to_bool(OutputFormatChoice.Json) is True
+
+    def test_auto_to_bool_for_sarif(self):
+        assert VulnerabilityAliasChoice.Auto.to_bool(OutputFormatChoice.Sarif) is True
 
     def test_str(self):
         for choice in VulnerabilityAliasChoice:


### PR DESCRIPTION
## Summary
- Add `--format sarif` emitting schema-valid SARIF 2.1.0
- Omit `physicalLocation` for now (per prior maintainer guidance on #206)
- Wire CLI/docs/CHANGELOG; `--desc` / `--aliases` auto-on for sarif like json
- Fixes #206
## Test plan
- [x] `pytest test/format/test_sarif.py test/test_cli.py`
- [x] `ruff` / `mypy` / `interrogate` on new format module
