### PR TITLE
Fix --skip-editable with hashed requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Editable requirements skipped with `--skip-editable` no longer require a hash
+  when auditing hashed requirements files
+  ([#1024](https://github.com/pypa/pip-audit/issues/1024))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_dependency_source/requirement.py
+++ b/pip_audit/_dependency_source/requirement.py
@@ -300,6 +300,12 @@ class RequirementSource(DependencySource):
         """
         req_specifiers: dict[str, SpecifierSet] = {}
         for req in reqs:
+            if self._skip_editable and req.is_editable:
+                yield SkippedDependency(
+                    name=req.name or req.requirement_line.line,
+                    skip_reason="requirement marked as editable",
+                )
+                continue
             if not req.hash_options and require_hashes:
                 raise RequirementSourceError(f"requirement {req.dumps()} does not contain a hash")
             if req.req is None:
@@ -314,8 +320,6 @@ class RequirementSource(DependencySource):
                     skip_reason="could not deduce package version from URL requirement",
                 )
                 continue
-            if self._skip_editable and req.is_editable:
-                yield SkippedDependency(name=req.name, skip_reason="requirement marked as editable")
             if req.marker is not None and not req.marker.evaluate():
                 # TODO(ww): Remove this `no cover` pragma once we're 3.10+.
                 # See: https://github.com/nedbat/coveragepy/issues/198

--- a/test/dependency_source/test_requirement.py
+++ b/test/dependency_source/test_requirement.py
@@ -519,7 +519,30 @@ def test_requirement_source_disable_pip_editable_skip(req_file):
     )
 
     specs = list(source.collect())
-    assert SkippedDependency(name="flask", skip_reason="requirement marked as editable") in specs
+    assert specs == [SkippedDependency(name="flask", skip_reason="requirement marked as editable")]
+
+
+def test_requirement_source_disable_pip_editable_skip_with_hashes(req_file):
+    source = _init_requirement(
+        [
+            (
+                req_file(),
+                "-e file:.\n"
+                "wheel==0.38.1 "
+                "--hash=sha256:"
+                "7a95f9a8dc0924ef318bd55b616112c70903192f524d120acc614f59547a9e1f",
+            )
+        ],
+        disable_pip=True,
+        no_deps=True,
+        skip_editable=True,
+    )
+
+    specs = list(source.collect())
+    assert specs == [
+        SkippedDependency(name="-e file:.", skip_reason="requirement marked as editable"),
+        ResolvedDependency(name="wheel", version=Version("0.38.1")),
+    ]
 
 
 def test_requirement_source_disable_pip_duplicate_dependencies(req_file):


### PR DESCRIPTION
Skip editable requirements before validating hashes in the pre-resolved dependency path. This prevents editable entries from failing with a missing-hash error when `--skip-editable` is enabled.

Adds a regression test for #1024.

Tests:
- `make test`
- `make lint`


Closes #1024