### PR TITLE
fix(_subprocess): use Popen.communicate() instead of poll/read loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.0.9 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed unsound subprocess stream handling that could split multi-byte UTF-8
+  sequences and deadlock on large `stderr` output, by using
+  `Popen.communicate()` instead of a manual `poll()`/`read()` loop
+  ([#574](https://github.com/pypa/pip-audit/issues/574))
+
 ## [2.10.1]
 
 ### Fixed

--- a/pip_audit/_subprocess.py
+++ b/pip_audit/_subprocess.py
@@ -39,29 +39,22 @@ def run(args: Sequence[str], *, log_stdout: bool = False, state: AuditState = Au
     # state updates, so we trim the first argument down to its basename.
     pretty_args = " ".join([os.path.basename(args[0]), *args[1:]])
 
-    terminated = False
-    stdout = b""
-    stderr = b""
+    # Rather than draining `stdout`/`stderr` with a manual `poll()`/`read()` loop
+    # (which can deadlock when `stderr` fills its pipe buffer, and can split a
+    # multi-byte UTF-8 sequence mid-codepoint and produce mojibake), we use
+    # `Popen.communicate()` to read both streams concurrently and return complete,
+    # correctly-decoded output.
+    with Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+        stdout, stderr = process.communicate()
 
-    # Run the process with unbuffered I/O, to make the poll-and-read loop below
-    # more responsive.
-    with Popen(args, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
-        # NOTE: We use `poll()` to control this loop instead of the `read()` call
-        # to prevent deadlocks. Similarly, `read(size)` will return an empty bytes
-        # once `stdout` hits EOF, so we don't have to worry about that blocking.
-        while not terminated:
-            terminated = process.poll() is not None
-            stdout += process.stdout.read()  # type: ignore
-            stderr += process.stderr.read()  # type: ignore
-            state.update_state(
-                f"Running {pretty_args}",
-                stdout.decode(errors="replace") if log_stdout else None,
-            )
+    if process.returncode != 0:
+        raise CalledProcessError(
+            f"{pretty_args} exited with {process.returncode}",
+            stderr=stderr.decode(errors="replace"),
+        )
 
-        if process.returncode != 0:
-            raise CalledProcessError(
-                f"{pretty_args} exited with {process.returncode}",
-                stderr=stderr.decode(errors="replace"),
-            )
-
+    state.update_state(
+        f"Running {pretty_args}",
+        stdout.decode(errors="replace") if log_stdout else None,
+    )
     return stdout.decode("utf-8", errors="replace")

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from pip_audit._subprocess import CalledProcessError, run
@@ -6,3 +8,12 @@ from pip_audit._subprocess import CalledProcessError, run
 def test_run_raises():
     with pytest.raises(CalledProcessError):
         run(["false"])
+
+
+def test_run_unicode_output():
+    # Multi-byte UTF-8 output must be returned intact, without mojibake caused by
+    # splitting the byte stream mid-codepoint (see #574).
+    out = run(
+        [sys.executable, "-c", "import sys; sys.stdout.buffer.write('日本語 🔒'.encode())"]
+    )
+    assert out == "日本語 🔒"


### PR DESCRIPTION
Fixes #574.

## Summary
The `run()` helper in `pip_audit/_subprocess.py` drained `stdout`/`stderr` with a manual `poll()`/`read()` loop. This approach is unsound: it can deadlock when `stderr` fills its pipe buffer (while we block reading `stdout`), and reading raw byte chunks can split a multi-byte UTF-8 sequence mid-codepoint, producing mojibake.

This PR replaces the loop with `Popen.communicate()`, which reads both streams concurrently and returns complete, correctly-decoded output.

## Trade-off / follow-up
`communicate()` returns output only after the process exits, so we lose the per-chunk progress updates to `AuditState`. If the maintainers prefer to keep the live spinner, I can re-add incremental updates via a threaded reader with an incremental UTF-8 decoder. Happy to adjust.

## Testing
- Added `test_run_unicode_output` regression test in `test/test_subprocess.py`.
- `py_compile` passes; full test suite runs in CI.
